### PR TITLE
Add colored output with --color flag (auto/always/never)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,7 @@
 rhood/
 ├── rhood.py               # Main application (entry point, ~1050 lines)
 ├── orders.py              # Data model classes: order, multi_orders, dividend
+├── colors.py              # ANSI color output module (--color auto/always/never)
 ├── requirements.txt       # Pinned Python dependencies
 ├── run.sh                 # Scheduled execution wrapper (cron/task scheduler)
 ├── TestSuite.sh           # Bash test harness (22 test combinations)
@@ -29,6 +30,7 @@ rhood/
 ## Key Files
 
 - **`rhood.py`** - All application logic: login, API calls, order parsing, profit calculation, CSV export, pickle save/load, argparse CLI. Uses procedural style with global state and UPPERCASE function names for major operations.
+- **`colors.py`** - ANSI color output module. Controlled via `--color` flag (auto/always/never). `auto` enables color when stdout is a TTY. All color functions are no-ops when disabled, ensuring clean output for piping and file redirection.
 - **`orders.py`** - Three data classes:
   - `order` - Single buy/sell transaction (date, type, price, quantity, value)
   - `multi_orders` - All orders for a symbol with profit calculation methods
@@ -66,7 +68,7 @@ python rhood.py --profile-info
 python rhood.py --finance-info
 ```
 
-Key CLI flags: `--all-info`, `--profile-info`, `--finance-info`, `--save`, `--load`, `--extra`, `--csv`, `--profile-csv`, `--sort-by-name`, `--insecure`, `--username`, `--password`, `--authkey`, `--creds-file`, `--finance-file`, `--csv-dir`.
+Key CLI flags: `--all-info`, `--profile-info`, `--finance-info`, `--save`, `--load`, `--extra`, `--csv`, `--profile-csv`, `--sort-by-name`, `--color` (auto/always/never), `--insecure`, `--username`, `--password`, `--authkey`, `--creds-file`, `--finance-file`, `--csv-dir`.
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -1,29 +1,256 @@
-# RHOOD - Robinhood Stocks Analysis
+# rhood -- Robinhood Portfolio Analyzer
 
-Rhood provides an analysis of your Robinhood portfolio using the robin_stocks API. It provides all of the profile data, order data, open positions, net profits, dividends, and total profits in a single text output.
+A Python CLI tool that pulls your entire Robinhood trading history via the [robin_stocks](https://github.com/jmfernandes/robin_stocks) API and calculates **per-symbol net profit** across stocks, crypto, and dividends.
 
-Rhood provides an excellent way to see your profit for each symbol ever held. Robinhood webapp & native application doesn't provide this information (at least I couldn't find it). You can see your total revenue, and you can see symbols total return. However, robinhood's total return per symbol, seems to clear out if you sell the whole symbol; or maybe part sell of the symbol distorts it too - I am not sure. My application, rhood, tells you the total return of each stock regardless of sales. This gives you a good idea as to which stocks, crypto or option* were your most advantageous (and least advantageous).
+Robinhood's own app doesn't show you true total return per symbol - especially after partial or full sells. rhood does.
 
-As this generates very private data, the output should be viewed with discretely.
+> **Privacy warning:** Output contains sensitive financial data. Handle it carefully.
 
-Example output 1 - provided by generous online user (this is the bottom portion; above this you would see all of the orders by each category and parsed by each symbol):
+![Example output](https://user-images.githubusercontent.com/62363157/110397276-66fe8180-8026-11eb-8474-a75a135fbf9b.png)
 
-![image](https://user-images.githubusercontent.com/62363157/110397276-66fe8180-8026-11eb-8474-a75a135fbf9b.png)
+---
 
-Example output 2 - which is made up but shows general concept:
+## Table of Contents
 
-```console
-...many lines cut off for brevity (cut lines might have shown all profile info, all orders and open positions)...
+- [Quick Start](#quick-start)
+- [Requirements](#requirements)
+- [Authentication](#authentication)
+  - [Method 1: Credentials File with 2FA (recommended)](#method-1-credentials-file-with-2fa-recommended)
+  - [Method 2: Credentials File without 2FA](#method-2-credentials-file-without-2fa)
+  - [Method 3: CLI Arguments](#method-3-cli-arguments)
+- [Usage](#usage)
+  - [Get All Data](#get-all-data)
+  - [Profile or Finance Only](#profile-or-finance-only)
+  - [Save and Load (Caching)](#save-and-load-caching)
+  - [CSV Export](#csv-export)
+  - [Extra Order Detail](#extra-order-detail)
+  - [Color Output](#color-output)
+  - [Sort Order](#sort-order)
+  - [Searching for a Symbol](#searching-for-a-symbol)
+- [How Profit is Calculated](#how-profit-is-calculated)
+- [CLI Reference](#cli-reference)
+- [Scheduling and Archiving](#scheduling-and-archiving)
+- [Project Structure](#project-structure)
+- [Limitations](#limitations)
+- [TODO](#todo)
 
+---
+
+## Quick Start
+
+```bash
+git clone https://github.com/bhbmaster/rhood
+cd rhood
+pip install -r requirements.txt
+
+# Without 2FA:
+python rhood.py --all-info -U 'you@email.com' -P 'YourPassword' --insecure
+
+# With 2FA (recommended):
+python rhood.py --all-info -U 'you@email.com' -P 'YourPassword' -A 'YOUR2FAKEY'
+```
+
+> **What is the 2FA key?** It is the alphanumeric secret (e.g. `TZIJ9PPENAA2X69Z`) shown once when you first enable "authenticator app" 2FA in Robinhood. It is **not** the 6-digit rotating code. See [Robinhood 2FA docs](https://robinhood.com/us/en/support/articles/twofactor-authentication/) and [robin_stocks TOTP guide](https://github.com/jmfernandes/robin_stocks#with-mfa-entered-programmatically-from-time-based-one-time-password-totp).
+
+---
+
+## Requirements
+
+| Requirement | Version |
+|---|---|
+| Python | 3.9+ (tested on 3.9, 3.10, 3.11) |
+| robin-stocks | >= 3.4.0 |
+| pyotp | >= 2.9.0 |
+| python-dateutil | >= 2.9.0 |
+
+```bash
+pip install -r requirements.txt
+```
+
+> **Important:** `robin-stocks` 3.4.0+ is required. Older versions (e.g. 3.0.6) have a bug where login errors crash with `KeyError: 'detail'` instead of showing the real error.
+
+---
+
+## Authentication
+
+rhood supports two ways to provide credentials: a **credentials file** (better for scripting) or **CLI arguments** (quick one-off runs). Both methods support 2FA ("secure") and non-2FA ("insecure") login.
+
+> The `--insecure` flag just means "no 2FA". Both modes use the Robinhood API over HTTPS and your credentials are not stored by rhood.
+
+### Method 1: Credentials File with 2FA (recommended)
+
+1. Create a plain text file called `creds` with three lines:
+
+```
+you@email.com
+YourPassword
+YOUR2FAKEY
+```
+
+2. Encode it and delete the original:
+
+```bash
+cat creds | base64 > creds-encoded
+cat creds-encoded | base64 -d   # verify it decodes correctly
+rm creds
+```
+
+3. Run rhood (it reads `creds-encoded` automatically):
+
+```bash
+python rhood.py --all-info
+# or all features:
+python rhood.py --all-info --extra --save --csv --profile-csv
+```
+
+### Method 2: Credentials File without 2FA
+
+Same as above, but with only two lines (email and password) and add `--insecure`:
+
+```
+you@email.com
+YourPassword
+```
+
+```bash
+cat creds | base64 > creds-encoded && rm creds
+python rhood.py --all-info --insecure
+# or all features;
+python rhood.py --all-info --extra --save --csv --profile-csv --insecure
+```
+
+> If you have 2FA enabled but use `--insecure`, Robinhood will prompt for the MFA code interactively, which makes it unsuitable for scripting.
+
+### Method 3: CLI Arguments
+
+```bash
+# With 2FA
+python rhood.py --all-info -U 'you@email.com' -P 'YourPassword' -A 'YOUR2FAKEY'
+
+# Without 2FA
+python rhood.py --all-info -U 'you@email.com' -P 'YourPassword' --insecure
+```
+
+Use `-C` / `--creds-file` to specify a non-default credentials file path:
+
+```bash
+python rhood.py --all-info --creds-file /path/to/my-creds-encoded
+```
+
+---
+
+## Usage
+
+### Get All Data
+
+The main command that prints everything -- profile info, all orders, open positions, net profits, dividends, and total profit:
+
+```bash
+python rhood.py --all-info
+```
+
+The "kitchen sink" command that also saves a cache, exports CSVs, and includes extra API detail:
+
+```bash
+python rhood.py --all-info --extra --save --csv --profile-csv
+```
+
+### Profile or Finance Only
+
+```bash
+python rhood.py --profile-info      # only account/profile data
+python rhood.py --finance-info      # only orders, positions, profits, dividends
+```
+
+Using both `--profile-info --finance-info` together is equivalent to `--all-info`.
+
+### Save and Load (Caching)
+
+Fetching all orders from the API can be slow. Save the data locally and reload it later:
+
+```bash
+python rhood.py --all-info --save        # fetches from API, saves to dat.pkl
+python rhood.py --all-info --load        # loads from dat.pkl (fast, skips API)
+```
+
+The pickle file stores: run date, username, all stock/crypto/option orders, open positions (with prices at save time), and dividends.
+
+Use `-F` / `--finance-file` to change the pickle filename (default: `dat.pkl`).
+
+> `--save` and `--load` cannot be used together.
+
+### CSV Export
+
+```bash
+python rhood.py --all-info --csv                # financial data to CSV
+python rhood.py --all-info --profile-csv        # profile data to CSV
+python rhood.py --all-info --csv --profile-csv  # both
+```
+
+CSV files are saved to `csv/YYYYMMDD-HHMM-username/`. Use `-D` / `--csv-dir` to change the output directory.
+
+### Extra Order Detail
+
+By default, rhood only shows essential order fields (date, side, price, quantity, state). Use `--extra` to include all raw API fields:
+
+```bash
+python rhood.py --all-info --extra
+```
+
+### Color Output
+
+rhood supports ANSI-colored output (profits in green/red, buy/sell highlighting, section headers):
+
+```bash
+python rhood.py --all-info --color auto      # default: color when stdout is a TTY
+python rhood.py --all-info --color always     # force color (e.g. piping to 'less -R')
+python rhood.py --all-info --color never      # plain text (clean for file redirection)
+```
+
+### Sort Order
+
+Open positions and net profits are sorted by value (lowest to highest) by default. Sort alphabetically instead:
+
+```bash
+python rhood.py --all-info --sort-by-name
+```
+
+### Searching for a Symbol
+
+Generate full output to a file, then grep for your symbol:
+
+```bash
+python rhood.py --all-info --extra --save > output.txt 2>&1
+grep TSLA output.txt
+```
+
+This shows all TSLA orders (raw + parsed), open positions, and net profit in one view.
+
+---
+
+## How Profit is Calculated
+
+```
+Net Profit per Symbol = (Sum of filled Sells) - (Sum of filled Buys) + (Open Position Value)
+Total Net Profit      = Sum of all symbol net profits
+Total Dividends       = Sum of all paid dividends
+Total Profit          = Total Net Profit + Total Dividends
+```
+
+- Only **filled** orders count. Cancelled, pending, and queued orders are ignored.
+- Open position values are estimates using the current ask price (fluctuates in real-time).
+- Only **paid** dividends are included. Pending dividends use an estimated date.
+
+**Example output:**
+
+```
 STOCKS:
 * STOCK CBAT net profit $-3.73
 * STOCK MGM net profit $27.25 ** currently open **
-* STOCK NCLH net profit $11.66 ** currently open **
 * STOCK SPCE net profit $169.44
 * STOCK total net profit $204.62
 
 CRYPTO:
-* CRYPTO ETH net profit $-3.31
 * CRYPTO BTC net profit $67.34 ** currently open **
 * CRYPTO total net profit $64.03
 
@@ -31,468 +258,121 @@ TOTAL NET PROFIT:
 * total net profit from stocks, crypto, and options: $268.65
 
 --- Profits from Dividends ---
-* dividend from SPXL on 2020-07-01 11:18:12 +0000 for $0.19 (paid)
-* dividend from AAPL on 2020-08-14 13:18:03 +0000 for $0.60 (paid)
+* dividend from AAPL on 2020-08-14 for $0.60 (paid)
 TOTAL DIVIDEND PAY: $0.79
 
 TOTAL PROFIT (NET PROFIT + DIVIDENDS):
 * total profit from stocks, crypto, and options + dividends: $269.44
 ```
 
-**Requirements:** Python 3.9+ and the packages listed in `requirements.txt`: `robin-stocks>=3.4.0`, `pyotp`, and `python-dateutil`
+---
 
-**Tested Successfully:** Python 3.9, 3.10, 3.11
+## CLI Reference
 
-**Robinhood API used:** https://github.com/jmfernandes/robin_stocks
-
-The tested Python versions and pinned module versions are listed in `requirements.txt`.
-
-**Note:** `robin-stocks` version 3.4.0 or later is required. Earlier versions (e.g., 3.0.6) have a known bug where login error handling crashes with a `KeyError: 'detail'` instead of showing the actual error message.
-
-## WORK IN PROGRESS
-
-* See todo list at the bottom. Options + Margins are not taken into account, yet.
-
-## SHELL QUICK START GUIDE
-
-Here is a quick start guide for shell users:
-
-```bash
-# Install rhood
-
-git clone https://github.com/bhbmaster/rhood
-cd rhood
-
-# Install its dependencies
-
-pip install -r requirements.txt
-
-# Run rhood using method A or method B:
-
-# Method A -- if you do not have 2 factor authentication enabled run this:
-
-python rhood.py --all-info --username 'your@email.com' --password 'YOURPASSWORD' --insecure
-
-# Method B -- if you have 2 factor authentication enabled and have your authentication key (its an alphanumeric code provided only once at the beginning of your 2 factor authentication setup) run this:
-
-python rhood.py --all-info --username 'your@email.com' --password 'YOURPASSWORD' --authkey 'YOUR2FACTORCODE'
-```
-
-**SIDENOTE 1:** The 2 factor authentication key 'YOUR2FACTORCODE' is not the 6 digit code you get every time you want to login. Instead its an alphanumeric code presented at the beginning of setting up your 2 factor. IT looks like this 'TZIJ9PPENAA2X69Z' (this is not anyones code. I changed the characters.)
-
-**SIDENOTE 2:** It is called --insecure, for the purposes of labeling my code. I labeled none 2 factor authentication as "insecure" and 2 factor auth as "secure". The actual login for both methods is still done over API and your credentials are not saved anywhere, so both are actually secure methods.
-
-**SIDENOTE 3:** If rhood is ran often or in a script, its recommended to use a 'creds-encoded' file instead of supplying the credentials in the CLI. More information on creds files and all of the login methods are described below.
-
-**SIDENOTE 4:** If MFA / 2 factor authentication enabled, --insecure mode will work, however it will prompt for the generated MFA code. Therefore due to the keyboard intervention, its not supported to script with.
-
-## HOW TO USE RHOOD
-
-First select a login method, preferably more secure ones. Then select the arguments you want to use. Most likely --all-info to start off, that just give - all the info (all profile info, all orders, open positions, net profits, dividends, and total profits)
-
-## LOGIN METHODS
-
-There are 4 methods of login in. In order from least to most secure:
-
-1. secure login using base64 encoded file 'creds-encoded' that has username/email on first line and password on second line and authkey on third line (pre-encoding)
-1. insecure login using base64 encoded file 'creds-encoded' that has username/email on first line and password on second line (pre-encoding)
-1. secure login with CLI using --username --password and --authkey
-1. insecure login with CLI --username and --password
-
-secure vs insecure simply means, secure is your account has 2 factor authentication mode, where as insecure means your account does not have 2 factor authentication.
-
-## LOGIN METHOD 1 ) LOGIN SECURELY - USE AUTHENTICATION KEY AND CREATE CREDS FILE
-
-For this to work, I encourage to use 2 factor authentication. Please set it up. I installed the Google Authenticator app on my phone and then I enabled 2 factor from Robinhood app the "authentication with an app" 2 factor method (not the SMS method).
-
-**More instructions 1:** https://github.com/jmfernandes/robin_stocks#with-mfa-entered-programmatically-from-time-based-one-time-password-totp (Specifically read the text. The code doesn't matter as similar login code is implemented in rhood)
-
-**More instructions 2:** https://robinhood.com/us/en/support/articles/twofactor-authentication/
-
-You will be given an alphanumeric API key that looks like this "TZIJ9PPENAA2X69Z". You will use it to create the credentials file below.
-
-**NOTE:** I am not sure if the 2 factor with SMS method works, it might. If it doesn't then just switch to 2 factor with an app
-
-###  CREATE ENCODED CREDS FILE
-
-Before we can do any work, first create a credentials files called 'creds-encoded'.
-
-Its an encoded file of your email, password, and API key. We start with a clear text credentials file 'creds', but then we convert it to be encoded for extra security.
-
-**NOTE:** Although, having an encoded credentials file provides an extra level of security so that your creds are not stored in clear text on your PC, please take extra caution your computer is secured other methods (perhaps accessing via 2 factor as well)
-
-Steps to create the encoded credentials file:
-
-1. Create a clear text 'creds' file which has 3 lines: UN, PW, and KEY. For me it looked like this:
-
-```console
-bhbmaster@gmail.com
-PineapplesExpress
-TZIJ9PPENAA2X69Z
-```
-
-1. Encode it with this python or bash command.
+| Flag | Short | Description |
+|---|---|---|
+| `--all-info` | `-i` | Show all profile + financial data (required for most output) |
+| `--profile-info` | | Profile data only |
+| `--finance-info` | | Financial data only (orders, positions, profits, dividends) |
+| `--save` | `-s` | Save fetched data to pickle file |
+| `--load` | `-l` | Load data from pickle file instead of API |
+| `--extra` | `-e` | Show all raw API fields for each order |
+| `--csv` | `-c` | Export financial data to CSV files |
+| `--profile-csv` | `-p` | Export profile data to CSV |
+| `--sort-by-name` | `-S` | Sort positions/profits alphabetically (default: by value) |
+| `--color` | | `auto` (default), `always`, or `never` |
+| `--insecure` | `-I` | Login without 2FA |
+| `--username` | `-U` | Robinhood email/username (CLI login) |
+| `--password` | `-P` | Robinhood password (CLI login) |
+| `--authkey` | `-A` | 2FA TOTP key (CLI login) |
+| `--creds-file` | `-C` | Path to credentials file (default: `creds-encoded`) |
+| `--finance-file` | `-F` | Path to pickle file (default: `dat.pkl`) |
+| `--csv-dir` | `-D` | Output directory for CSVs (default: `csv`) |
 
 ```bash
-# python command
-python -c 'import base64; print(base64.b64encode(open("creds","r").read().encode("utf-8")).decode("utf-8"))' > creds-encoded
-
-# bash command
-cat creds | base64 > creds-encoded
+python rhood.py --help    # full help text
 ```
 
-1. Verify you see an encoded file
+---
+
+## Scheduling and Archiving
+
+### Automated Runs
+
+Use `run.sh` to run rhood with full options and archive the results:
 
 ```bash
-cat creds-encoded
+./run.sh
 ```
 
-1. Verify the file decodes correctly. You should see your UN, PW, and KEY.
+This saves dated output to `archive/output/` and dated pickle files to `archive/dat/`.
+
+Schedule it with cron (Linux/Mac) or Task Scheduler (Windows via WSL/Cygwin):
 
 ```bash
-# python command
-python -c 'import base64; print(base64.b64decode(open("creds-encoded","r").read()).decode("utf-8"))'
-
-# bash command
-cat creds-encoded | base64 -d 2> /dev/null
+# crontab example: run every hour
+0 * * * * cd /path/to/rhood && ./run.sh
 ```
 
-Example output (modified for privacy):
+### Rotation and Compression
 
-```console
-PPhib3453455QGdtYWlsasERTVCXYWlyMTIz123412341230VlZFTkJLMlg0N1A=
-```
-
-1. If you see the original output, then delete the original file. The software will use the creds-encoded file to load your credentials by decoding it correctly.
+Over time, archived files can grow to many GiB. Use the rotation scripts to compress them:
 
 ```bash
-rm creds
+./archive/rotate.sh    # compress output + dat files to .xz / .tar.xz
+./csv/rotate.sh        # compress CSV directories to .tar.xz
 ```
 
-## LOGIN METHOD 2 ) LOGIN INSECURELY WITH CREDENTIALS FILE - NOT RECOMMENDED
+Schedule rotation weekly (e.g. every Sunday).
 
-One can login with username and password as well - without 2 factor authentication. It is not recommended, but it works.
+### Parsing Historical Output
 
-Follow the instructions above to create a creds-encoded file with just username and password, missing the auth key.
-
-So it would look like this pre encoding:
-
-```console
-bhbmaster@gmail.com
-PineapplesExpress
-```
-
-Then include the the --insecure (or -I) argument in all of your rhood.py commands.
-
-## LOGIN METHOD 3 and 4 ) USING CLI TO LOGIN
-
-If you have 2 factor authentication, you would use secure login with CLI like so:
+Analyze archived outputs to track profit trends over time:
 
 ```bash
-# syntax:
-python rhood.py --username bhbmaster@gmail.com --password PineapplesExpress --authkey TZIJ9PPENAA2X69Z [rest of the options]
-
-# example:
-python rhood.py --username bhbmaster@gmail.com --password PineapplesExpress --authkey TZIJ9PPENAA2X69Z --all-info
+cd archive
+./parse-outputs.sh          # display on screen
+./parse-outputs.sh save     # save to archive/parse.out
 ```
 
-If you have 2 factor authentication disabled, you would use insecure login with CLI like so:
+This works on both uncompressed and rotated (compressed) files.
 
-```bash
-# syntax:
-python rhood.py --username bhbmaster@gmail.com --password PineapplesExpress [rest of the options]
+---
 
-# example:
-python rhood.py --username bhbmaster@gmail.com --password PineapplesExpress --all-info
-```
-
-**SIDENOTE:** instead of using --username, --password, and --authkey which are 'wordy', you can use -U, -P and -A respectivly.
-
-## PRINT ALL INFORMATION
-
-Add the --all-info argument to rhood (-i for short) to print all profile information (lots of sensitive information), order information (Stock, Crypto, Option), open positions, net profits (see note below), dividends, and total profits.
-
-```bash
-python rhood.py --all-info
-```
-
-**NOTE:** To get any information out of rhood, you must at least use --all-info. Without it, its only useful to be played with interactively (see Playground).
-
-**NOTE OF PROFIT CALCULATION:** Net Profits are calculated by subtracting the sum of the buy from the sells, then adding the open positions value. The open position values are calculated by multiplying current help quantity by the current ask_price (which is always changing). Therefore, if a stock, crypto or option is open then we are only getting an estimate of the profit by assuming we also sell the entire stock right now. If a symbol is currently closed (no quantity is held), then open position value can be ignored as its just 0. The term symbol refers to stocks, crypto coins, and options. Then dividend profit is calculated by summing all paid dividends. Total profit is the sum of dividend profits and net profits.
-
-```console
-Net Profit For Symbol = (Sum of filled Sells) - (Sum of filled Buys) + (Open Position Value)
-Dividends = (Sum of all paid dividends)
-Total Profit = (Sum of all Net Profits from all symbols) + (Dividends)
-```
-
-## ONLY GETTING PROFILE INFORMATION OR FINANCIAL INFORMATION
-
-Getting all of the information might not be the intent. So other then using a bunch of grep and regex on the final output to get the desired info. You can specify if you want just the profile information (--profile-info), or financial information (--finance-info).
-
-Profile information includes only profile data. This switch can be used with --profile-csv. Other switches that rely on --finance-info will just be ignored (no errors shown)
-
-```bash
-python rhood.py --profile-info
-```
-
-Finance info includes only financial data (order information, open positions, net profits, dividends, and total profits). This switch can be used with --csv, --load, --save, --extra. Other switches that rely on --profile-info, will be ignored.
-
-```bash
-python rhood.py --finance-info
-```
-
-If both profile-info and finance-info switches are used, then its equivalent of just using --all-info. This way all switches work, --save, --load, --extra, --csv, --profile-csv.
-
-```bash
-python rhood.py --finance-info --profile-info  # both of these lines return the same output
-python rhood.py --all-info                     # both of these lines return the same output
-```
-
-**SIDENOTE:** The old --info switch was renamed to --all-info
-
-## SAVING AND LOADING FINANCE INFORMATION
-
-Checking the API for all of the orders + open positions + dividends is time consuming. Try to save the data locally & loading it. Of course if any changes were done since then, we will not have the most up to date information. 
-
-Save order information to dat.pkl:
-
-```bash
-python rhood.py --all-info --save
-```
-
-Load order information from dat.pkl:
-
-```bash
-python rhood.py --all-info --load
-```
-
-**SIDENOTE:** Saving and loading only makes sense if you also use --all-info/-i option 
-
-**SIDENOTE:** -s is short for --save, -l is short for --load
-
-**SIDENOTE:** The following data is saved in the file as a dictionary object: run date, loaded username, stocks orders list of dict, crypto orders list of dict, options orders list of dict, stock order dictionary, crypto order dictionary, stocks open list of dict, cryptos open list of dict, options open list of dict, sod, cod, ood, dividends.. sod, cod, and ood is another list of dict of open positions, however, it also contains prices at the run date (allowing to view the price of the open symbol at later date when we use --load)
-## GENERATE CSVs
-
-The --csv or -c option save all of the stock, crypto and options orders + open positions + profits + dividends into CSV files. It saves the data as its recieved from the API. This can be loaded from saved orders (with --load option) file or directly from API (with out --load option).
-
-```bash
-python rhood.py --all-info --csv
-```
-
-To save all profile data use the --profile-csv switch
-
-```bash
-python rhood.py --all-info --profile-csv         # save profile info to csvs
-python rhood.py --all-info --profile-csv --csv   # save profile info & stock orders + open positions + profits + dividends to csv 
-```
-
-## COLOR OUTPUT
-
-Rhood supports colored terminal output via the `--color` flag. Colors highlight profits/losses, buy/sell sides, section headers, and errors for easier reading.
-
-```bash
-python rhood.py --all-info --color auto      # default: color when stdout is a TTY
-python rhood.py --all-info --color always     # force color (useful for piping to 'less -R')
-python rhood.py --all-info --color never      # no color (clean output for file redirection)
-```
-
-When `--color` is set to `auto` (the default), colors are enabled when outputting to a terminal and disabled when piping to a file or another command. This ensures clean output in `> output.txt` redirections.
-
-## EXTRA INFORMATION ABOUT ORDERS
-
-To view all of the information returned from the robinhood API about every order run it with --extra option or --csv option (csv saves the same information). This extra information is omitted during normal operations as we are only concerned with each orders: date, price, amount, state.
-
-```bash
-python rhood.py --all-info --extra              # Can use extra when all info is shown.
-python rhood.py --finance-info --extra          # Or can use extra with finance-info (it won't do anything with profile-info).
-python rhood.py --all-info --extra --load       # Can also load saved orders to lower API time. Works with all-info.
-python rhood.py --finance-info --extra --load   # Can also load saved orders to lower API time. Works with finance-info.
+## Project Structure
 
 ```
-
-This option can be ran with --save and --load. Even though load offers speed increases by avoiding contacting the API for order parsing, this option will still be a little time consuming as contact the API to map IDs to Symbol names.
-
-## PARSING WITH GREP FOR A SPECIFIC SYMBOL
-
-Here is how to get information about a specific symbol you have traded (stock or crypto).
-
-First generate the all of the financial information by running one of the three commands below (just run one; they all return equally important data for the current purpose):
-
-```bash
-python rhood.py --all-info --extra --save --csv > output.txt 2>&1
-python rhood.py --finance-info --extra --save --csv > output.txt 2>&1
-./run.sh                             # this also generates an output.txt and saves dated output & pkl file into archive/ouput and archive/dat
+rhood/
+├── rhood.py            # Main application (~1050 lines)
+├── orders.py           # Data models: order, multi_orders, dividend
+├── colors.py           # ANSI color output (--color auto/always/never)
+├── requirements.txt    # Pinned Python dependencies
+├── run.sh              # Automated execution wrapper
+├── TestSuite.sh        # Bash test harness (22 combinations)
+├── README.md           # Original documentation
+├── README-better.md    # This file
+├── archive/
+│   ├── parse-outputs.sh   # Parse archived outputs for profit trends
+│   └── rotate.sh          # Compress archived output/dat files
+└── csv/
+    └── rotate.sh          # Compress CSV directories
 ```
 
-Then grep the output for your stock:
+---
 
-```bash
-cat output.txt | grep TSLA
-```
+## Limitations
 
-**SIDENOTE:** grep is a linux/unix/mac program that searches for strings that match a specific regular expression (search string). In other words for the example above, this shows me only the lines that have the word TSLA in them. Windows users can also get grep if they utilize some sort of linux emulator such as cygwin, or windows 10's bash ability.
+- **Options trading** is not yet implemented (stub functions exist but return nothing).
+- **Margins** are untested.
+- Open position values are real-time estimates based on current ask price.
+- `--load` only works if the logged-in username matches the one in the pickle file.
+- Pending dividend pay dates are estimated as the current run date.
+- `robin-stocks` v3.4.0 has a known issue where `get_all_option_positions` doesn't work correctly.
 
-The above command has the following output for a random user:
-
-```console
-2020-07-13T18:15:55.663576Z - a1053cf0-abcde-4910-9e04-abcde - buy  x0.06341400  TSLA [S|filled] avg: $1576.94  exec1/2: $1574.70 price: $1654.93
-...lines skipped for brevity...
-2020-12-09T15:53:58.910000Z - bc4c8aed-abcde-46dd-8106-abcde - buy  x2.00000000  TSLA [S|filled] avg: $639.68   exec1/1: $639.68  price: $671.58
-2020-12-14T18:48:28.147000Z - 75985dd4-abcde-495a-adf3-abcde - buy  x1.00000000  TSLA [S|filled] avg: $637.19   exec1/1: $637.19  price: $669.10
-
-...lines skiped for brevity...
-* sym# 10/44 ord# 34/48 tot_ord# 156 - 2020-11-19 16:34:42 +0000 - TSLA - buy - x1.0 at $506.59000 - value $506.59
-* sym# 10/44 ord# 35/48 tot_ord# 157 - 2020-11-19 16:59:37 +0000 - TSLA - sell - x2.0 at $499.55000 - value $999.10
-
-* OPEN STOCK - TSLA x3.0 at $634.13 each - est current value: $1902.38
-* TSLA net profit $695.66 ** currently open **
-```
-
-**Sidenote:** Above information shows the order information as shown by the robinhood API, followed by the info as it was parsed by rhood.py (this is similar to the returned API order info, except it also shows the value), then it shows any open positions, finally it shows the net profits. From this data, we see there is a total of 42 orders with TSLA with 3 open stocks and profited $695 so far. Since this is an open stock, we will only see that full profit after selling all of TSLA at current ask price ($634.13). If TSLA paid dividends (they currently do not), then that profit would appear on here too.
-
-## HELP
-
-Run this to see all of the options.
-
-```bash
-python rhood.py --help
-```
-
-Full list of CLI flags: `--all-info` (`-i`), `--profile-info`, `--finance-info`, `--save` (`-s`), `--load` (`-l`), `--extra` (`-e`), `--csv` (`-c`), `--profile-csv` (`-p`), `--sort-by-name` (`-S`), `--color` (auto/always/never), `--insecure` (`-I`), `--username` (`-U`), `--password` (`-P`), `--authkey` (`-A`), `--creds-file` (`-C`), `--finance-file` (`-F`), `--csv-dir` (`-D`).
-
-## SCHEDULING
-
-You can run this script on repeat per a schedule (example daily) and analyze the results separately. For example grepping for "net profit" and then viewing how your net profit changes every day.
-
-You can schedule the script to run in windows with Windows task scheduler that will run a bat file, that kicks off the run.sh shell script. For windows you need cygwin or another source of a bash.exe to get this running.
-
-In Linux/MAC you can schedule run.sh to run on a crontask. On Windows we kick off run.bat to kick off the run.sh:
-
-* run.sh --> this script runs rhood.py with extra information and saves output to a dated output file and a dated pickle file in archive/output and archive/dat. missing folders are created.
-* run.bat --> batch script to kick off run.sh from windows. not included but you can make it. it just kick off run.sh with cygwins bash
-
-run.bat would have contents similar to this:
-
-**run.bat**
-
-```batch
-@echo off
-c:
-cd \path\to\your\rhood\
-c:\path\to\your\bash.exe -c "cd /cygdrive/c/path/to/your/rhood; ./run.sh"
-```
-
-If you want run.bat to also run the parse-outputs.sh, I recommend doing it with WSL2 (Windows Subsystem for Linux). Personally I have Ubuntu installed as WSL. Thru cygwin parsing compressed results (if they exist) took me 1 hour, where as with WSL they took 1.5 minutes.
-
-**run.bat**: with added option to kick off parse-outputs.sh
-
-```batch
-@echo off
-c:
-cd \path\to\your\rhood\
-c:\path\to\your\bash.exe -c "cd /cygdrive/c/path/to/your/rhood; ./run.sh"
-wsl /mnt/path/to/your/rhood/archive/parse-outputs.sh save
-```
-
-Also schedule the archive/rotate.sh & csv/rotate.sh script to run once every few days (I run mine once every Sunday). On Windows, you will need to create a similar bat file for it:
-
-* archive/rotate.sh --> this script compressed the archived dat files into single tar.xz files and the archived output files into txt.xz. The txt.xz can later be analyzed along with the uncompressed output files with parse-outputs.sh.
-* archive/rotate.bat --> batch script to kick off the rotate.sh from windows. not included but you can make it. it just kicks off rotate.sh with cygwins bash
-
-**archive/rotate.bat**
-
-```batch
-@echo off
-c:
-cd \path\to\your\rhood\archive
-c:\path\to\your\bash.exe -c "cd /cygdrive/c/path/to/your/rhood/archive; ./rotate.sh"
-```
-* csv/rotate.sh --> this script compressed the sub directories in csv directory into single tar.xz file. It can later be extracted to be viewed. I recommend extracting in a different directory so it doesn't mess with the next rotation.
-* csv/rotate.bat --> batch script to kick off the rotate.sh from windows. not included but you can make it. it just kicks off rotate.sh with cygwins bash
-
-**csv/rotate.bat**
-
-```batch
-@echo off
-d:
-cd \path\to\your\rhood\csv
-c:\cygwin64\bin\bash.exe -c "cd /cygdrive/c/path/to/your/rhood/csv; ./rotate.sh"
-```
-
-More information on scheduling: I recommend scheduleing a run.sh or run.bat to run every hour of every day, then every 7 days run rotate.sh to help clear up space.
-
-## THE OUTPUT OF run.sh AND rotate.sh FUNCTIONALITY
-
-When **run.sh** is ran it saves a dated copy of the output into `archive/output/` directory and the pickle info into `archive/dat/`. Overtime, you can get thousands of these files. So I created a **rotate.sh** file that rotates those files out and creates smart compressed xz files. Overtime the uncompressed content can grow to a few GiB. For example,  for me they grew to 50GiB after a 1.5 years of running. The compressing tool shrunk it to 20MiB. There is no way to uncompress the output files back into their original multiple file format (as they were modified before being compressed -- if you are curious, each line was prefixed with the date -> this makes it possible to parse the compressed results in one swoop later). You can however get the original dat files back by simply extracting the dat*tar.xz file.
-
-There is also a **rotate.sh** script inside of csv directory which similary rotates/compresses the csv directories.
-
-## PARSING THE output FILES
-
-We are not saving the output files for no reason. They can be analyzed for further analysis. I made a script **parse-output.sh** that parses the older compressed files first (that were created by **rotate.sh**) and then the new uncompressed files (which were not yet processed by **rotate.sh**)
-
-Additionally there is a **parse-outputs.sh** file that generates oneline output of each run showing the most important profit information per line. It goes chronologically from oldest to newest, and it even works on the rotated files.
-
-To run it and show results on screen:
-```bash
-cd rhood/archive
-./parse-output.sh
-```
-
-To save the results to **rhood/archive/parse.out** (note the start and end date is appended to back and front of parse.out)
-```bash
-cd rhood/archive
-./parse-output.sh save
-```
-
-## EXTRA INFORMATION
-
-* Only filled orders are taken into account. orders that were cancelled or are currently pending / queued do not take into account for order parsing, open positions, or profit calculations.
-
-* Open positions and net profits are sorted from lowest value symbols to highest. you can use the --sort-name (-S) option to instead sort alphabetically by name.
-
-* Only paid dividends are taken into account for total profit from dividends
-
-* If --save & --load option is used, the 'dat.pkl' file contains the following information: username, run date & time, all of the stock, crypto and options orders (as received from API), and all of the stock, crypto and option open positions, and dividends.
-
-* Option --finance-file or -F can be used to specify a different file to save and load finance info (so you are not limited to it being named 'dat.pkl')
-
-* Option --creds-file or -C can be used to specify a different credentials file (so you are not limited to it being named 'creds-encoded')
-
-* Option --csv-dir or -D can be used to specify a different output directory for --csv and --profile-csv output. (By default the csv files are saved to 'csv' directory. Do not worry, if its missing its created.)
-
-
-## LIMITATIONS
-
-* The --load option only works if the username logging in matches the username saved in the 'dat.pkl' file.
-
-* If dividend payment is pending, the pay date is estimated to current run date. Only consider pay dates of "paid" dividends.
+---
 
 ## TODO
 
-- [ ] Options are not yet included as I don't have any. Looking for any information regarding how the data structure or output look like for the APIs methods: option orders, and option open positions.
-
-- [x] Add rotating/compressing of csv output files
-
-- [x] Added parsing of output files and rotating/compressing of output and dat files.
-
-- [x] If we use --load data from pickle file, then we should also use the ask_price of open positions at the loaded date, instead of the current date. otherwise the value will constantly change. This will give correct profits on that date. we could include option to evaluate loaded open positions with current ask price (--eval-loaded-current, -L), however, if stock splits occurred then we will be in a mathematics mess, that I don't want to deal with. Solution: save the ask_price when --save is used, and --load it, therefore we bypass needing to look up historical prices. **(DONE)**
-
-- [x] Allow insecure credentials, without 2factor authentication. add --insecure / -I flag. due to 2 methods of login, we now have to remove interactive mode (it was useless anyways). **(DONE, need to test.)**
-
-- [x] Sort open positions & net profits alphabetically, or by value. default value, include option --sort-by-name / -S. **(DONE)**
-
-- [x] Add login for secure and insecure mode using CLI arguments, without needing 'creds-encoded' file. Will add --username (-U), --password (-P), --authkey (--K). **(DONE)**
-
-- [x] Add dividend profit to my calculations. **(DONE)**
-
-- [ ] Total all buys per symbol, and all sells per symbol, and ratio with profits and study what that means.
-
-- [ ] Test if output works with Margins.
-
-- [x] Update to latest robin-stocks to work with python3.11
-
-- [x] Add `--color` flag (auto/always/never) with ANSI color output for profits, buy/sell sides, headers, and errors via `colors.py` module **(DONE)**
-
-- [x] Update robin-stocks from 3.0.6 to 3.4.0 to fix login `KeyError: 'detail'` bug **(DONE)**
+- [ ] Implement options order parsing and profit calculation
+- [ ] Test margin account output
+- [ ] Per-symbol buy/sell totals and ratios

--- a/README.md
+++ b/README.md
@@ -39,13 +39,15 @@ TOTAL PROFIT (NET PROFIT + DIVIDENDS):
 * total profit from stocks, crypto, and options + dividends: $269.44
 ```
 
-**Requirements:** python3.9 + pip install robin_stocks, pyotp, and python-dateutil
+**Requirements:** Python 3.9+ and the packages listed in `requirements.txt`: `robin-stocks>=3.4.0`, `pyotp`, and `python-dateutil`
 
-**Tested Successfully:** python3.10, python3.11
+**Tested Successfully:** Python 3.9, 3.10, 3.11
 
 **Robinhood API used:** https://github.com/jmfernandes/robin_stocks
 
-The tested versions are python3.9 and the modules listed in requirements.txt (along with the tested versions).
+The tested Python versions and pinned module versions are listed in `requirements.txt`.
+
+**Note:** `robin-stocks` version 3.4.0 or later is required. Earlier versions (e.g., 3.0.6) have a known bug where login error handling crashes with a `KeyError: 'detail'` instead of showing the actual error message.
 
 ## WORK IN PROGRESS
 
@@ -285,6 +287,18 @@ python rhood.py --all-info --profile-csv         # save profile info to csvs
 python rhood.py --all-info --profile-csv --csv   # save profile info & stock orders + open positions + profits + dividends to csv 
 ```
 
+## COLOR OUTPUT
+
+Rhood supports colored terminal output via the `--color` flag. Colors highlight profits/losses, buy/sell sides, section headers, and errors for easier reading.
+
+```bash
+python rhood.py --all-info --color auto      # default: color when stdout is a TTY
+python rhood.py --all-info --color always     # force color (useful for piping to 'less -R')
+python rhood.py --all-info --color never      # no color (clean output for file redirection)
+```
+
+When `--color` is set to `auto` (the default), colors are enabled when outputting to a terminal and disabled when piping to a file or another command. This ensures clean output in `> output.txt` redirections.
+
 ## EXTRA INFORMATION ABOUT ORDERS
 
 To view all of the information returned from the robinhood API about every order run it with --extra option or --csv option (csv saves the same information). This extra information is omitted during normal operations as we are only concerned with each orders: date, price, amount, state.
@@ -344,6 +358,8 @@ Run this to see all of the options.
 ```bash
 python rhood.py --help
 ```
+
+Full list of CLI flags: `--all-info` (`-i`), `--profile-info`, `--finance-info`, `--save` (`-s`), `--load` (`-l`), `--extra` (`-e`), `--csv` (`-c`), `--profile-csv` (`-p`), `--sort-by-name` (`-S`), `--color` (auto/always/never), `--insecure` (`-I`), `--username` (`-U`), `--password` (`-P`), `--authkey` (`-A`), `--creds-file` (`-C`), `--finance-file` (`-F`), `--csv-dir` (`-D`).
 
 ## SCHEDULING
 
@@ -476,3 +492,7 @@ cd rhood/archive
 - [ ] Test if output works with Margins.
 
 - [x] Update to latest robin-stocks to work with python3.11
+
+- [x] Add `--color` flag (auto/always/never) with ANSI color output for profits, buy/sell sides, headers, and errors via `colors.py` module **(DONE)**
+
+- [x] Update robin-stocks from 3.0.6 to 3.4.0 to fix login `KeyError: 'detail'` bug **(DONE)**

--- a/_archive/README-old.md
+++ b/_archive/README-old.md
@@ -1,0 +1,498 @@
+# RHOOD - Robinhood Stocks Analysis
+
+Rhood provides an analysis of your Robinhood portfolio using the robin_stocks API. It provides all of the profile data, order data, open positions, net profits, dividends, and total profits in a single text output.
+
+Rhood provides an excellent way to see your profit for each symbol ever held. Robinhood webapp & native application doesn't provide this information (at least I couldn't find it). You can see your total revenue, and you can see symbols total return. However, robinhood's total return per symbol, seems to clear out if you sell the whole symbol; or maybe part sell of the symbol distorts it too - I am not sure. My application, rhood, tells you the total return of each stock regardless of sales. This gives you a good idea as to which stocks, crypto or option* were your most advantageous (and least advantageous).
+
+As this generates very private data, the output should be viewed with discretely.
+
+Example output 1 - provided by generous online user (this is the bottom portion; above this you would see all of the orders by each category and parsed by each symbol):
+
+![image](https://user-images.githubusercontent.com/62363157/110397276-66fe8180-8026-11eb-8474-a75a135fbf9b.png)
+
+Example output 2 - which is made up but shows general concept:
+
+```console
+...many lines cut off for brevity (cut lines might have shown all profile info, all orders and open positions)...
+
+STOCKS:
+* STOCK CBAT net profit $-3.73
+* STOCK MGM net profit $27.25 ** currently open **
+* STOCK NCLH net profit $11.66 ** currently open **
+* STOCK SPCE net profit $169.44
+* STOCK total net profit $204.62
+
+CRYPTO:
+* CRYPTO ETH net profit $-3.31
+* CRYPTO BTC net profit $67.34 ** currently open **
+* CRYPTO total net profit $64.03
+
+TOTAL NET PROFIT:
+* total net profit from stocks, crypto, and options: $268.65
+
+--- Profits from Dividends ---
+* dividend from SPXL on 2020-07-01 11:18:12 +0000 for $0.19 (paid)
+* dividend from AAPL on 2020-08-14 13:18:03 +0000 for $0.60 (paid)
+TOTAL DIVIDEND PAY: $0.79
+
+TOTAL PROFIT (NET PROFIT + DIVIDENDS):
+* total profit from stocks, crypto, and options + dividends: $269.44
+```
+
+**Requirements:** Python 3.9+ and the packages listed in `requirements.txt`: `robin-stocks>=3.4.0`, `pyotp`, and `python-dateutil`
+
+**Tested Successfully:** Python 3.9, 3.10, 3.11
+
+**Robinhood API used:** https://github.com/jmfernandes/robin_stocks
+
+The tested Python versions and pinned module versions are listed in `requirements.txt`.
+
+**Note:** `robin-stocks` version 3.4.0 or later is required. Earlier versions (e.g., 3.0.6) have a known bug where login error handling crashes with a `KeyError: 'detail'` instead of showing the actual error message.
+
+## WORK IN PROGRESS
+
+* See todo list at the bottom. Options + Margins are not taken into account, yet.
+
+## SHELL QUICK START GUIDE
+
+Here is a quick start guide for shell users:
+
+```bash
+# Install rhood
+
+git clone https://github.com/bhbmaster/rhood
+cd rhood
+
+# Install its dependencies
+
+pip install -r requirements.txt
+
+# Run rhood using method A or method B:
+
+# Method A -- if you do not have 2 factor authentication enabled run this:
+
+python rhood.py --all-info --username 'your@email.com' --password 'YOURPASSWORD' --insecure
+
+# Method B -- if you have 2 factor authentication enabled and have your authentication key (its an alphanumeric code provided only once at the beginning of your 2 factor authentication setup) run this:
+
+python rhood.py --all-info --username 'your@email.com' --password 'YOURPASSWORD' --authkey 'YOUR2FACTORCODE'
+```
+
+**SIDENOTE 1:** The 2 factor authentication key 'YOUR2FACTORCODE' is not the 6 digit code you get every time you want to login. Instead its an alphanumeric code presented at the beginning of setting up your 2 factor. IT looks like this 'TZIJ9PPENAA2X69Z' (this is not anyones code. I changed the characters.)
+
+**SIDENOTE 2:** It is called --insecure, for the purposes of labeling my code. I labeled none 2 factor authentication as "insecure" and 2 factor auth as "secure". The actual login for both methods is still done over API and your credentials are not saved anywhere, so both are actually secure methods.
+
+**SIDENOTE 3:** If rhood is ran often or in a script, its recommended to use a 'creds-encoded' file instead of supplying the credentials in the CLI. More information on creds files and all of the login methods are described below.
+
+**SIDENOTE 4:** If MFA / 2 factor authentication enabled, --insecure mode will work, however it will prompt for the generated MFA code. Therefore due to the keyboard intervention, its not supported to script with.
+
+## HOW TO USE RHOOD
+
+First select a login method, preferably more secure ones. Then select the arguments you want to use. Most likely --all-info to start off, that just give - all the info (all profile info, all orders, open positions, net profits, dividends, and total profits)
+
+## LOGIN METHODS
+
+There are 4 methods of login in. In order from least to most secure:
+
+1. secure login using base64 encoded file 'creds-encoded' that has username/email on first line and password on second line and authkey on third line (pre-encoding)
+1. insecure login using base64 encoded file 'creds-encoded' that has username/email on first line and password on second line (pre-encoding)
+1. secure login with CLI using --username --password and --authkey
+1. insecure login with CLI --username and --password
+
+secure vs insecure simply means, secure is your account has 2 factor authentication mode, where as insecure means your account does not have 2 factor authentication.
+
+## LOGIN METHOD 1 ) LOGIN SECURELY - USE AUTHENTICATION KEY AND CREATE CREDS FILE
+
+For this to work, I encourage to use 2 factor authentication. Please set it up. I installed the Google Authenticator app on my phone and then I enabled 2 factor from Robinhood app the "authentication with an app" 2 factor method (not the SMS method).
+
+**More instructions 1:** https://github.com/jmfernandes/robin_stocks#with-mfa-entered-programmatically-from-time-based-one-time-password-totp (Specifically read the text. The code doesn't matter as similar login code is implemented in rhood)
+
+**More instructions 2:** https://robinhood.com/us/en/support/articles/twofactor-authentication/
+
+You will be given an alphanumeric API key that looks like this "TZIJ9PPENAA2X69Z". You will use it to create the credentials file below.
+
+**NOTE:** I am not sure if the 2 factor with SMS method works, it might. If it doesn't then just switch to 2 factor with an app
+
+###  CREATE ENCODED CREDS FILE
+
+Before we can do any work, first create a credentials files called 'creds-encoded'.
+
+Its an encoded file of your email, password, and API key. We start with a clear text credentials file 'creds', but then we convert it to be encoded for extra security.
+
+**NOTE:** Although, having an encoded credentials file provides an extra level of security so that your creds are not stored in clear text on your PC, please take extra caution your computer is secured other methods (perhaps accessing via 2 factor as well)
+
+Steps to create the encoded credentials file:
+
+1. Create a clear text 'creds' file which has 3 lines: UN, PW, and KEY. For me it looked like this:
+
+```console
+bhbmaster@gmail.com
+PineapplesExpress
+TZIJ9PPENAA2X69Z
+```
+
+1. Encode it with this python or bash command.
+
+```bash
+# python command
+python -c 'import base64; print(base64.b64encode(open("creds","r").read().encode("utf-8")).decode("utf-8"))' > creds-encoded
+
+# bash command
+cat creds | base64 > creds-encoded
+```
+
+1. Verify you see an encoded file
+
+```bash
+cat creds-encoded
+```
+
+1. Verify the file decodes correctly. You should see your UN, PW, and KEY.
+
+```bash
+# python command
+python -c 'import base64; print(base64.b64decode(open("creds-encoded","r").read()).decode("utf-8"))'
+
+# bash command
+cat creds-encoded | base64 -d 2> /dev/null
+```
+
+Example output (modified for privacy):
+
+```console
+PPhib3453455QGdtYWlsasERTVCXYWlyMTIz123412341230VlZFTkJLMlg0N1A=
+```
+
+1. If you see the original output, then delete the original file. The software will use the creds-encoded file to load your credentials by decoding it correctly.
+
+```bash
+rm creds
+```
+
+## LOGIN METHOD 2 ) LOGIN INSECURELY WITH CREDENTIALS FILE - NOT RECOMMENDED
+
+One can login with username and password as well - without 2 factor authentication. It is not recommended, but it works.
+
+Follow the instructions above to create a creds-encoded file with just username and password, missing the auth key.
+
+So it would look like this pre encoding:
+
+```console
+bhbmaster@gmail.com
+PineapplesExpress
+```
+
+Then include the the --insecure (or -I) argument in all of your rhood.py commands.
+
+## LOGIN METHOD 3 and 4 ) USING CLI TO LOGIN
+
+If you have 2 factor authentication, you would use secure login with CLI like so:
+
+```bash
+# syntax:
+python rhood.py --username bhbmaster@gmail.com --password PineapplesExpress --authkey TZIJ9PPENAA2X69Z [rest of the options]
+
+# example:
+python rhood.py --username bhbmaster@gmail.com --password PineapplesExpress --authkey TZIJ9PPENAA2X69Z --all-info
+```
+
+If you have 2 factor authentication disabled, you would use insecure login with CLI like so:
+
+```bash
+# syntax:
+python rhood.py --username bhbmaster@gmail.com --password PineapplesExpress [rest of the options]
+
+# example:
+python rhood.py --username bhbmaster@gmail.com --password PineapplesExpress --all-info
+```
+
+**SIDENOTE:** instead of using --username, --password, and --authkey which are 'wordy', you can use -U, -P and -A respectivly.
+
+## PRINT ALL INFORMATION
+
+Add the --all-info argument to rhood (-i for short) to print all profile information (lots of sensitive information), order information (Stock, Crypto, Option), open positions, net profits (see note below), dividends, and total profits.
+
+```bash
+python rhood.py --all-info
+```
+
+**NOTE:** To get any information out of rhood, you must at least use --all-info. Without it, its only useful to be played with interactively (see Playground).
+
+**NOTE OF PROFIT CALCULATION:** Net Profits are calculated by subtracting the sum of the buy from the sells, then adding the open positions value. The open position values are calculated by multiplying current help quantity by the current ask_price (which is always changing). Therefore, if a stock, crypto or option is open then we are only getting an estimate of the profit by assuming we also sell the entire stock right now. If a symbol is currently closed (no quantity is held), then open position value can be ignored as its just 0. The term symbol refers to stocks, crypto coins, and options. Then dividend profit is calculated by summing all paid dividends. Total profit is the sum of dividend profits and net profits.
+
+```console
+Net Profit For Symbol = (Sum of filled Sells) - (Sum of filled Buys) + (Open Position Value)
+Dividends = (Sum of all paid dividends)
+Total Profit = (Sum of all Net Profits from all symbols) + (Dividends)
+```
+
+## ONLY GETTING PROFILE INFORMATION OR FINANCIAL INFORMATION
+
+Getting all of the information might not be the intent. So other then using a bunch of grep and regex on the final output to get the desired info. You can specify if you want just the profile information (--profile-info), or financial information (--finance-info).
+
+Profile information includes only profile data. This switch can be used with --profile-csv. Other switches that rely on --finance-info will just be ignored (no errors shown)
+
+```bash
+python rhood.py --profile-info
+```
+
+Finance info includes only financial data (order information, open positions, net profits, dividends, and total profits). This switch can be used with --csv, --load, --save, --extra. Other switches that rely on --profile-info, will be ignored.
+
+```bash
+python rhood.py --finance-info
+```
+
+If both profile-info and finance-info switches are used, then its equivalent of just using --all-info. This way all switches work, --save, --load, --extra, --csv, --profile-csv.
+
+```bash
+python rhood.py --finance-info --profile-info  # both of these lines return the same output
+python rhood.py --all-info                     # both of these lines return the same output
+```
+
+**SIDENOTE:** The old --info switch was renamed to --all-info
+
+## SAVING AND LOADING FINANCE INFORMATION
+
+Checking the API for all of the orders + open positions + dividends is time consuming. Try to save the data locally & loading it. Of course if any changes were done since then, we will not have the most up to date information. 
+
+Save order information to dat.pkl:
+
+```bash
+python rhood.py --all-info --save
+```
+
+Load order information from dat.pkl:
+
+```bash
+python rhood.py --all-info --load
+```
+
+**SIDENOTE:** Saving and loading only makes sense if you also use --all-info/-i option 
+
+**SIDENOTE:** -s is short for --save, -l is short for --load
+
+**SIDENOTE:** The following data is saved in the file as a dictionary object: run date, loaded username, stocks orders list of dict, crypto orders list of dict, options orders list of dict, stock order dictionary, crypto order dictionary, stocks open list of dict, cryptos open list of dict, options open list of dict, sod, cod, ood, dividends.. sod, cod, and ood is another list of dict of open positions, however, it also contains prices at the run date (allowing to view the price of the open symbol at later date when we use --load)
+## GENERATE CSVs
+
+The --csv or -c option save all of the stock, crypto and options orders + open positions + profits + dividends into CSV files. It saves the data as its recieved from the API. This can be loaded from saved orders (with --load option) file or directly from API (with out --load option).
+
+```bash
+python rhood.py --all-info --csv
+```
+
+To save all profile data use the --profile-csv switch
+
+```bash
+python rhood.py --all-info --profile-csv         # save profile info to csvs
+python rhood.py --all-info --profile-csv --csv   # save profile info & stock orders + open positions + profits + dividends to csv 
+```
+
+## COLOR OUTPUT
+
+Rhood supports colored terminal output via the `--color` flag. Colors highlight profits/losses, buy/sell sides, section headers, and errors for easier reading.
+
+```bash
+python rhood.py --all-info --color auto      # default: color when stdout is a TTY
+python rhood.py --all-info --color always     # force color (useful for piping to 'less -R')
+python rhood.py --all-info --color never      # no color (clean output for file redirection)
+```
+
+When `--color` is set to `auto` (the default), colors are enabled when outputting to a terminal and disabled when piping to a file or another command. This ensures clean output in `> output.txt` redirections.
+
+## EXTRA INFORMATION ABOUT ORDERS
+
+To view all of the information returned from the robinhood API about every order run it with --extra option or --csv option (csv saves the same information). This extra information is omitted during normal operations as we are only concerned with each orders: date, price, amount, state.
+
+```bash
+python rhood.py --all-info --extra              # Can use extra when all info is shown.
+python rhood.py --finance-info --extra          # Or can use extra with finance-info (it won't do anything with profile-info).
+python rhood.py --all-info --extra --load       # Can also load saved orders to lower API time. Works with all-info.
+python rhood.py --finance-info --extra --load   # Can also load saved orders to lower API time. Works with finance-info.
+
+```
+
+This option can be ran with --save and --load. Even though load offers speed increases by avoiding contacting the API for order parsing, this option will still be a little time consuming as contact the API to map IDs to Symbol names.
+
+## PARSING WITH GREP FOR A SPECIFIC SYMBOL
+
+Here is how to get information about a specific symbol you have traded (stock or crypto).
+
+First generate the all of the financial information by running one of the three commands below (just run one; they all return equally important data for the current purpose):
+
+```bash
+python rhood.py --all-info --extra --save --csv > output.txt 2>&1
+python rhood.py --finance-info --extra --save --csv > output.txt 2>&1
+./run.sh                             # this also generates an output.txt and saves dated output & pkl file into archive/ouput and archive/dat
+```
+
+Then grep the output for your stock:
+
+```bash
+cat output.txt | grep TSLA
+```
+
+**SIDENOTE:** grep is a linux/unix/mac program that searches for strings that match a specific regular expression (search string). In other words for the example above, this shows me only the lines that have the word TSLA in them. Windows users can also get grep if they utilize some sort of linux emulator such as cygwin, or windows 10's bash ability.
+
+The above command has the following output for a random user:
+
+```console
+2020-07-13T18:15:55.663576Z - a1053cf0-abcde-4910-9e04-abcde - buy  x0.06341400  TSLA [S|filled] avg: $1576.94  exec1/2: $1574.70 price: $1654.93
+...lines skipped for brevity...
+2020-12-09T15:53:58.910000Z - bc4c8aed-abcde-46dd-8106-abcde - buy  x2.00000000  TSLA [S|filled] avg: $639.68   exec1/1: $639.68  price: $671.58
+2020-12-14T18:48:28.147000Z - 75985dd4-abcde-495a-adf3-abcde - buy  x1.00000000  TSLA [S|filled] avg: $637.19   exec1/1: $637.19  price: $669.10
+
+...lines skiped for brevity...
+* sym# 10/44 ord# 34/48 tot_ord# 156 - 2020-11-19 16:34:42 +0000 - TSLA - buy - x1.0 at $506.59000 - value $506.59
+* sym# 10/44 ord# 35/48 tot_ord# 157 - 2020-11-19 16:59:37 +0000 - TSLA - sell - x2.0 at $499.55000 - value $999.10
+
+* OPEN STOCK - TSLA x3.0 at $634.13 each - est current value: $1902.38
+* TSLA net profit $695.66 ** currently open **
+```
+
+**Sidenote:** Above information shows the order information as shown by the robinhood API, followed by the info as it was parsed by rhood.py (this is similar to the returned API order info, except it also shows the value), then it shows any open positions, finally it shows the net profits. From this data, we see there is a total of 42 orders with TSLA with 3 open stocks and profited $695 so far. Since this is an open stock, we will only see that full profit after selling all of TSLA at current ask price ($634.13). If TSLA paid dividends (they currently do not), then that profit would appear on here too.
+
+## HELP
+
+Run this to see all of the options.
+
+```bash
+python rhood.py --help
+```
+
+Full list of CLI flags: `--all-info` (`-i`), `--profile-info`, `--finance-info`, `--save` (`-s`), `--load` (`-l`), `--extra` (`-e`), `--csv` (`-c`), `--profile-csv` (`-p`), `--sort-by-name` (`-S`), `--color` (auto/always/never), `--insecure` (`-I`), `--username` (`-U`), `--password` (`-P`), `--authkey` (`-A`), `--creds-file` (`-C`), `--finance-file` (`-F`), `--csv-dir` (`-D`).
+
+## SCHEDULING
+
+You can run this script on repeat per a schedule (example daily) and analyze the results separately. For example grepping for "net profit" and then viewing how your net profit changes every day.
+
+You can schedule the script to run in windows with Windows task scheduler that will run a bat file, that kicks off the run.sh shell script. For windows you need cygwin or another source of a bash.exe to get this running.
+
+In Linux/MAC you can schedule run.sh to run on a crontask. On Windows we kick off run.bat to kick off the run.sh:
+
+* run.sh --> this script runs rhood.py with extra information and saves output to a dated output file and a dated pickle file in archive/output and archive/dat. missing folders are created.
+* run.bat --> batch script to kick off run.sh from windows. not included but you can make it. it just kick off run.sh with cygwins bash
+
+run.bat would have contents similar to this:
+
+**run.bat**
+
+```batch
+@echo off
+c:
+cd \path\to\your\rhood\
+c:\path\to\your\bash.exe -c "cd /cygdrive/c/path/to/your/rhood; ./run.sh"
+```
+
+If you want run.bat to also run the parse-outputs.sh, I recommend doing it with WSL2 (Windows Subsystem for Linux). Personally I have Ubuntu installed as WSL. Thru cygwin parsing compressed results (if they exist) took me 1 hour, where as with WSL they took 1.5 minutes.
+
+**run.bat**: with added option to kick off parse-outputs.sh
+
+```batch
+@echo off
+c:
+cd \path\to\your\rhood\
+c:\path\to\your\bash.exe -c "cd /cygdrive/c/path/to/your/rhood; ./run.sh"
+wsl /mnt/path/to/your/rhood/archive/parse-outputs.sh save
+```
+
+Also schedule the archive/rotate.sh & csv/rotate.sh script to run once every few days (I run mine once every Sunday). On Windows, you will need to create a similar bat file for it:
+
+* archive/rotate.sh --> this script compressed the archived dat files into single tar.xz files and the archived output files into txt.xz. The txt.xz can later be analyzed along with the uncompressed output files with parse-outputs.sh.
+* archive/rotate.bat --> batch script to kick off the rotate.sh from windows. not included but you can make it. it just kicks off rotate.sh with cygwins bash
+
+**archive/rotate.bat**
+
+```batch
+@echo off
+c:
+cd \path\to\your\rhood\archive
+c:\path\to\your\bash.exe -c "cd /cygdrive/c/path/to/your/rhood/archive; ./rotate.sh"
+```
+* csv/rotate.sh --> this script compressed the sub directories in csv directory into single tar.xz file. It can later be extracted to be viewed. I recommend extracting in a different directory so it doesn't mess with the next rotation.
+* csv/rotate.bat --> batch script to kick off the rotate.sh from windows. not included but you can make it. it just kicks off rotate.sh with cygwins bash
+
+**csv/rotate.bat**
+
+```batch
+@echo off
+d:
+cd \path\to\your\rhood\csv
+c:\cygwin64\bin\bash.exe -c "cd /cygdrive/c/path/to/your/rhood/csv; ./rotate.sh"
+```
+
+More information on scheduling: I recommend scheduleing a run.sh or run.bat to run every hour of every day, then every 7 days run rotate.sh to help clear up space.
+
+## THE OUTPUT OF run.sh AND rotate.sh FUNCTIONALITY
+
+When **run.sh** is ran it saves a dated copy of the output into `archive/output/` directory and the pickle info into `archive/dat/`. Overtime, you can get thousands of these files. So I created a **rotate.sh** file that rotates those files out and creates smart compressed xz files. Overtime the uncompressed content can grow to a few GiB. For example,  for me they grew to 50GiB after a 1.5 years of running. The compressing tool shrunk it to 20MiB. There is no way to uncompress the output files back into their original multiple file format (as they were modified before being compressed -- if you are curious, each line was prefixed with the date -> this makes it possible to parse the compressed results in one swoop later). You can however get the original dat files back by simply extracting the dat*tar.xz file.
+
+There is also a **rotate.sh** script inside of csv directory which similary rotates/compresses the csv directories.
+
+## PARSING THE output FILES
+
+We are not saving the output files for no reason. They can be analyzed for further analysis. I made a script **parse-output.sh** that parses the older compressed files first (that were created by **rotate.sh**) and then the new uncompressed files (which were not yet processed by **rotate.sh**)
+
+Additionally there is a **parse-outputs.sh** file that generates oneline output of each run showing the most important profit information per line. It goes chronologically from oldest to newest, and it even works on the rotated files.
+
+To run it and show results on screen:
+```bash
+cd rhood/archive
+./parse-output.sh
+```
+
+To save the results to **rhood/archive/parse.out** (note the start and end date is appended to back and front of parse.out)
+```bash
+cd rhood/archive
+./parse-output.sh save
+```
+
+## EXTRA INFORMATION
+
+* Only filled orders are taken into account. orders that were cancelled or are currently pending / queued do not take into account for order parsing, open positions, or profit calculations.
+
+* Open positions and net profits are sorted from lowest value symbols to highest. you can use the --sort-name (-S) option to instead sort alphabetically by name.
+
+* Only paid dividends are taken into account for total profit from dividends
+
+* If --save & --load option is used, the 'dat.pkl' file contains the following information: username, run date & time, all of the stock, crypto and options orders (as received from API), and all of the stock, crypto and option open positions, and dividends.
+
+* Option --finance-file or -F can be used to specify a different file to save and load finance info (so you are not limited to it being named 'dat.pkl')
+
+* Option --creds-file or -C can be used to specify a different credentials file (so you are not limited to it being named 'creds-encoded')
+
+* Option --csv-dir or -D can be used to specify a different output directory for --csv and --profile-csv output. (By default the csv files are saved to 'csv' directory. Do not worry, if its missing its created.)
+
+
+## LIMITATIONS
+
+* The --load option only works if the username logging in matches the username saved in the 'dat.pkl' file.
+
+* If dividend payment is pending, the pay date is estimated to current run date. Only consider pay dates of "paid" dividends.
+
+## TODO
+
+- [ ] Options are not yet included as I don't have any. Looking for any information regarding how the data structure or output look like for the APIs methods: option orders, and option open positions.
+
+- [x] Add rotating/compressing of csv output files
+
+- [x] Added parsing of output files and rotating/compressing of output and dat files.
+
+- [x] If we use --load data from pickle file, then we should also use the ask_price of open positions at the loaded date, instead of the current date. otherwise the value will constantly change. This will give correct profits on that date. we could include option to evaluate loaded open positions with current ask price (--eval-loaded-current, -L), however, if stock splits occurred then we will be in a mathematics mess, that I don't want to deal with. Solution: save the ask_price when --save is used, and --load it, therefore we bypass needing to look up historical prices. **(DONE)**
+
+- [x] Allow insecure credentials, without 2factor authentication. add --insecure / -I flag. due to 2 methods of login, we now have to remove interactive mode (it was useless anyways). **(DONE, need to test.)**
+
+- [x] Sort open positions & net profits alphabetically, or by value. default value, include option --sort-by-name / -S. **(DONE)**
+
+- [x] Add login for secure and insecure mode using CLI arguments, without needing 'creds-encoded' file. Will add --username (-U), --password (-P), --authkey (--K). **(DONE)**
+
+- [x] Add dividend profit to my calculations. **(DONE)**
+
+- [ ] Total all buys per symbol, and all sells per symbol, and ratio with profits and study what that means.
+
+- [ ] Test if output works with Margins.
+
+- [x] Update to latest robin-stocks to work with python3.11
+
+- [x] Add `--color` flag (auto/always/never) with ANSI color output for profits, buy/sell sides, headers, and errors via `colors.py` module **(DONE)**
+
+- [x] Update robin-stocks from 3.0.6 to 3.4.0 to fix login `KeyError: 'detail'` bug **(DONE)**

--- a/colors.py
+++ b/colors.py
@@ -1,0 +1,116 @@
+import sys
+
+# ANSI escape codes
+RESET = "\033[0m"
+BOLD = "\033[1m"
+DIM = "\033[2m"
+RED = "\033[31m"
+GREEN = "\033[32m"
+YELLOW = "\033[33m"
+CYAN = "\033[36m"
+WHITE = "\033[37m"
+BRIGHT_RED = "\033[91m"
+BRIGHT_GREEN = "\033[92m"
+BRIGHT_YELLOW = "\033[93m"
+BRIGHT_WHITE = "\033[97m"
+
+_enabled = False
+
+def init(mode="auto"):
+    global _enabled
+    if mode == "always":
+        _enabled = True
+    elif mode == "never":
+        _enabled = False
+    else:  # auto
+        _enabled = hasattr(sys.stdout, 'isatty') and sys.stdout.isatty()
+
+def _wrap(codes, text):
+    if _enabled:
+        return f"{codes}{text}{RESET}"
+    return str(text)
+
+# basic styles
+def bold(text):
+    return _wrap(BOLD, text)
+
+def dim(text):
+    return _wrap(DIM, text)
+
+def red(text):
+    return _wrap(RED, text)
+
+def green(text):
+    return _wrap(GREEN, text)
+
+def yellow(text):
+    return _wrap(YELLOW, text)
+
+def cyan(text):
+    return _wrap(CYAN, text)
+
+# compound styles
+def bold_cyan(text):
+    return _wrap(BOLD + CYAN, text)
+
+def bold_red(text):
+    return _wrap(BOLD + RED, text)
+
+def bold_green(text):
+    return _wrap(BOLD + GREEN, text)
+
+def bold_yellow(text):
+    return _wrap(BOLD + YELLOW, text)
+
+def bold_white(text):
+    return _wrap(BOLD + WHITE, text)
+
+def bright_green(text):
+    return _wrap(BRIGHT_GREEN, text)
+
+def bright_red(text):
+    return _wrap(BRIGHT_RED, text)
+
+# semantic helpers
+def section(text):
+    return bold_cyan(text)
+
+def header(text):
+    return bold_white(text)
+
+def note(text):
+    return yellow(text)
+
+def warn(text):
+    return bold_yellow(text)
+
+def error(text):
+    return bold_red(text)
+
+def status(text):
+    return dim(text)
+
+def buy_sell(side):
+    s = str(side)
+    if s.lower() == "buy":
+        return red(s)
+    elif s.lower() == "sell":
+        return green(s)
+    return s
+
+def profit(value):
+    s = f"{float(value):.2f}"
+    v = float(value)
+    if v > 0:
+        return _wrap(BRIGHT_GREEN, f"${s}")
+    elif v < 0:
+        return _wrap(BRIGHT_RED, f"${s}")
+    return f"${s}"
+
+def open_marker(text=" ** currently open **"):
+    return _wrap(BOLD + BRIGHT_YELLOW, text)
+
+def symbol(text):
+    return bold(text)
+
+# EOF

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 pyotp==2.9.0
-robin-stocks==3.0.6
+robin-stocks==3.4.0
 python-dateutil==2.9.0.post0

--- a/rhood.py
+++ b/rhood.py
@@ -12,6 +12,7 @@ import pickle
 import os.path
 import os
 import csv
+import colors
 
 ###################
 #### PRE VARS #####
@@ -41,7 +42,7 @@ cryptopairs = None
 # error message
 def errmsg(message):
     print()
-    print(f"* ERROR: {message}")
+    print(colors.error(f"* ERROR: {message}"))
     print()
 
 # error and exit
@@ -190,7 +191,7 @@ def FORMAT_ORDER_STOCKS(RS_orders):
         execs = len(o["executions"]) if state == "filled" else "None"  # used to be state != "cancelled"
         price1 = TOMONEY(o["executions"][0]["price"]) if state == "filled" else "None"  # used to be state != "cancelled"
         price = TOMONEY(o["price"])
-        result += f'* {date} - {id} - {side}\tx{quantity}\t{symbol} [S|{state}]\tavg: ${priceavg}\texec1/{execs}: ${price1}\tprice: ${price}\n'
+        result += f'* {colors.dim(date)} - {colors.dim(id)} - {colors.buy_sell(side)}\tx{quantity}\t{colors.symbol(symbol)} [S|{state}]\tavg: ${priceavg}\texec1/{execs}: ${price1}\tprice: ${price}\n'
     return result
 
 # FORMAT CRYPTOS ORDERS TO EXTRA INFORMATION STRING
@@ -210,7 +211,7 @@ def FORMAT_ORDER_CRYPTOS(RS_orders):
         execs = len(o["executions"]) if state == "filled" else "None"  # used to be state != "cancelled"
         price1 = TOMONEY(o["executions"][0]["effective_price"]) if state == "filled" else "None"  # used to be state != "cancelled"
         price = TOMONEY(o["price"])
-        result += f'* {date} - {id} - {side}\t${rounded}\tx{quantity}\t{symbol} [C|{state}]\tavg: ${priceavg}\texec1/{execs}: ${price1}\tprice: ${price}\n'
+        result += f'* {colors.dim(date)} - {colors.dim(id)} - {colors.buy_sell(side)}\t${rounded}\tx{quantity}\t{colors.symbol(symbol)} [C|{state}]\tavg: ${priceavg}\texec1/{execs}: ${price1}\tprice: ${price}\n'
     return result
 
 # FORMAT OPTIONS ORDERS TO EXTRA INFORMATION STRING - TODO: test with options one date. might be similar to stocks just change to O in state field
@@ -232,7 +233,7 @@ def PRINT_ORDERS_DICTIONARY(stock_orders_dictionary):
         for order in obj.orders:
             total_order_num += 1;
             stock_order_num += 1
-            print(f"* sym# {stock_num}/{len_of_stocks} ord# {stock_order_num}/{len_of_orders} tot_ord# {total_order_num} - {order.date_nice()} - {symbol} - {order.type_string} - x{order.amount_float} at ${DX(order.price_float,5)} - value ${D2(order.value_float)}")
+            print(f"* {colors.dim(f'sym# {stock_num}/{len_of_stocks} ord# {stock_order_num}/{len_of_orders} tot_ord# {total_order_num}')} - {order.date_nice()} - {colors.symbol(symbol)} - {colors.buy_sell(order.type_string)} - x{order.amount_float} at ${DX(order.price_float,5)} - value ${D2(order.value_float)}")
 
 ###################
 
@@ -405,7 +406,7 @@ def save_data(filename,so,co,oo,sd,cd,od,soo,coo,ooo,sod,cod,ood,divs,verify_boo
         un = ld["username"] if ld["username"] is not None else "N/A"
         # print()
         # print(f"* saved data of {un} to {filename} of run_date {run_date} - {len_so} orders of {len_soo} open stocks of {len_sd} - {len_co} orders of {len_coo} open crypto of {len_cd} - {len_oo} orders of {len_ooo} open options of {len_od} - {len_divs} dividends")
-        print(f"* saved data of {un} to {filename} of run_date {run_date} - (total orders, open symbols, total symbols): stocks ({len_so},{len_soo}/{len_sd}) - crypto ({len_co},{len_coo}/{len_cd}) - options ({len_oo},{len_ooo}/{len_od}) - {len_divs} dividends")
+        print(colors.status(f"* saved data of {un} to {filename} of run_date {run_date} - (total orders, open symbols, total symbols): stocks ({len_so},{len_soo}/{len_sd}) - crypto ({len_co},{len_coo}/{len_cd}) - options ({len_oo},{len_ooo}/{len_od}) - {len_divs} dividends"))
         print()
 
 # load time consuming data from file
@@ -522,7 +523,7 @@ def PRINT_ALL_PROFILE_AND_ORDERS(save_bool=False,load_bool=False, extra_info_boo
         info_type_string = "Financial Information"
 
     # print date header
-    print(f"Date: {run_date} - Rhood Version: {Version} - {info_type_string}")
+    print(colors.bold(f"Date: {run_date} - Rhood Version: {Version} - {info_type_string}"))
     print()
 
     # preloading
@@ -530,7 +531,7 @@ def PRINT_ALL_PROFILE_AND_ORDERS(save_bool=False,load_bool=False, extra_info_boo
         # loading orders from pickle
         ld = load_data(FILENAME) # this is used below this if as well
         run_date_orders = ld['run_date']
-        print(f"* Preloading Complete")
+        print(colors.status(f"* Preloading Complete"))
         if ld["username"] != loaded_username:
             errext(2, "Loaded finance information of another user, can't do that. Please save current users data first using --save, if you wish to --load it at later point.")
         print()
@@ -543,20 +544,20 @@ def PRINT_ALL_PROFILE_AND_ORDERS(save_bool=False,load_bool=False, extra_info_boo
         prof_type = ["account","basic","investment","portfolio","security","user"]
         # save profiles to csv if csv_profile_bool
         for prof in prof_type:
-            print(f"---{prof} Profile---")
+            print(colors.section(f"---{prof} Profile---"))
             prof_func = getattr(r.profiles,f"load_{prof}_profile")
             prof_dictionary = prof_func()
             if csv_profile_bool:
                 print_to_csv(f"A-{prof}-profile",prof_dictionary)
-            print("\n".join([ f"* {i[0]}: {i[1]}" for i in prof_dictionary.items() ]))
+            print("\n".join([ f"* {colors.cyan(i[0])}: {i[1]}" for i in prof_dictionary.items() ]))
             print()
 
     if info_type == "ALL" or info_type == "FINANCE":
         # print account values
-        print(f"--- Gain Information (Experimental) ---")
-        print(f"* NOTE: Currently this section does not take into account cash management, options, and crypto. If only stocks are involved, then this section _should_ be accurate.")
-        print(f"* NOTE: The profit calculations in this section are inspired by https://github.com/jmfernandes/robin_stocks/blob/master/examples/get_accurate_gains.py")
-        print(f"* NOTE: The profit calculations below this section are more accurate as they consider every symbol order + current open positions + dividends")
+        print(colors.section(f"--- Gain Information (Experimental) ---"))
+        print(colors.note(f"* NOTE: Currently this section does not take into account cash management, options, and crypto. If only stocks are involved, then this section _should_ be accurate."))
+        print(colors.note(f"* NOTE: The profit calculations in this section are inspired by https://github.com/jmfernandes/robin_stocks/blob/master/examples/get_accurate_gains.py"))
+        print(colors.note(f"* NOTE: The profit calculations below this section are more accurate as they consider every symbol order + current open positions + dividends"))
 
         profileData = r.load_portfolio_profile()
         allTransactions = r.get_bank_transfers()
@@ -576,145 +577,145 @@ def PRINT_ALL_PROFILE_AND_ORDERS(save_bool=False,load_bool=False, extra_info_boo
         if extended_hours_equity_string is not None:
             extended_hours_equity = float(extended_hours_equity_string)
             use_equity = extended_hours_equity
-            print("* NOTE: extended_hours_equity exists, using it")
+            print(colors.note("* NOTE: extended_hours_equity exists, using it"))
         else:
             extended_hours_equity = None
             use_equity = equity
-            print("* NOTE: extended_hours_equity missing, using regular equity instead")
+            print(colors.note("* NOTE: extended_hours_equity missing, using regular equity instead"))
 
         totalGainMinusDividends = use_equity - dividends - money_invested # missing cash_account_debits + i think also missing crypto and options
         percentGain = totalGainMinusDividends/money_invested*100
 
-        print(f"* Reported Deposits: ${TOMONEY(deposits)}")
-        print(f"* Reported Withdrawals: ${TOMONEY(withdrawals)}")
-        print(f"* Reported Debits: ${TOMONEY(debits)} *** this is wrong right now ***") # <-- why is this 0, it should be all cash_account debits
+        print(f"* Reported Deposits: {colors.green('$'+TOMONEY(deposits))}")
+        print(f"* Reported Withdrawals: {colors.red('$'+TOMONEY(withdrawals))}")
+        print(f"* Reported Debits: ${TOMONEY(debits)} {colors.warn('*** this is wrong right now ***')}") # <-- why is this 0, it should be all cash_account debits
         print(f"* Reported Reversal Fees: ${TOMONEY(reversal_fees)}")
-        print(f"* The total money invested is ${TOMONEY(money_invested)}")
-        print(f"* The total equity is ${TOMONEY(equity)}")
-        print(f"* NOTE: extended_hours_equity is ${TOMONEY(extended_hours_equity)}") # added by me
-        print(f"* The net worth has increased {percentDividend:.3f}% due to dividends that amount to ${TOMONEY(dividends)}")
-        print(f"* The net worth has increased {TOMONEY(percentGain)}% due to other gains that amount to ${TOMONEY(totalGainMinusDividends)} *** correct if only stocks & no cash mgmt ***")
+        print(f"* The total money invested is {colors.bold('$'+TOMONEY(money_invested))}")
+        print(f"* The total equity is {colors.bold('$'+TOMONEY(equity))}")
+        print(colors.note(f"* NOTE: extended_hours_equity is ${TOMONEY(extended_hours_equity)}")) # added by me
+        print(f"* The net worth has increased {colors.bright_green(f'{percentDividend:.3f}%')} due to dividends that amount to {colors.green('$'+TOMONEY(dividends))}")
+        print(f"* The net worth has increased {TOMONEY(percentGain)}% due to other gains that amount to {colors.profit(totalGainMinusDividends)} {colors.warn('*** correct if only stocks & no cash mgmt ***')}")
         print()
 
         # print load stock + crypto + options - TIME CONSUMING
         if load_bool:
             # loading orders from pickle
             # no need to reverse, as we already saveed reversed
-            print(f"--- Loading Orders (from file) ---")
+            print(colors.section(f"--- Loading Orders (from file) ---"))
             ld = load_data(FILENAME) # this is used below this if as well
             run_date_orders = ld['run_date']
-            print(f"* loaded order data from '{FILENAME}' which ran on {run_date_orders}")
-            print(f"* (S) started stock orders load")
+            print(colors.status(f"* loaded order data from '{FILENAME}' which ran on {run_date_orders}"))
+            print(colors.status(f"* (S) started stock orders load"))
             stock_orders = ld["stock_orders"]
-            print(f"* (S) completed stock orders load")
-            print(f"* (C) started crypto orders load")
+            print(colors.status(f"* (S) completed stock orders load"))
+            print(colors.status(f"* (C) started crypto orders load"))
             crypto_orders = ld["crypto_orders"]
-            print(f"* (C) completed crypto orders load")
-            print(f"* (O) started option orders load")
+            print(colors.status(f"* (C) completed crypto orders load"))
+            print(colors.status(f"* (O) started option orders load"))
             option_orders = ld["option_orders"]
-            print(f"* (O) completed option orders load")
+            print(colors.status(f"* (O) completed option orders load"))
             print()
         else:
             # contacting order via API
-            print(f"--- Loading Orders (from API) ---")
+            print(colors.section(f"--- Loading Orders (from API) ---"))
             run_date_orders = run_date
-            print(f"* Loading orders via API on {run_date_orders}")
-            print(f"* (S) started stock orders load")
+            print(colors.status(f"* Loading orders via API on {run_date_orders}"))
+            print(colors.status(f"* (S) started stock orders load"))
             stock_orders = LOAD_STOCK_ORDERS()
             stock_orders.reverse()
-            print(f"* (S) completed stock orders load")
-            print(f"* (C) started crypto orders load")
+            print(colors.status(f"* (S) completed stock orders load"))
+            print(colors.status(f"* (C) started crypto orders load"))
             crypto_orders = LOAD_CRYPTO_ORDERS()
             crypto_orders.reverse()
-            print(f"* (C) completed crypto orders load")
-            print(f"* (O) started option orders load")
+            print(colors.status(f"* (C) completed crypto orders load"))
+            print(colors.status(f"* (O) started option orders load"))
             option_orders = LOAD_OPTION_ORDERS()
             option_orders.reverse()
-            print(f"* (O) completed option orders load")
+            print(colors.status(f"* (O) completed option orders load"))
             print()
 
         # print all stock orders (buy and sell)
         stocks_dict = {}
-        print(f"--- All Stock Orders ---")
+        print(colors.section(f"--- All Stock Orders ---"))
         if stock_orders != []:
             if extra_info_bool: # time consuming shows alot of extra information (like state of orders and more)
                 PRINT_STOCK_ORDERS(stock_orders)  ## time consuming
                 print()
                 if load_bool:
-                    print("...loading parsed stock orders...")
+                    print(colors.status("...loading parsed stock orders..."))
                     stocks_dict = ld["stocks_dict"]
                 else:
-                    print("...parsing stock orders...")
+                    print(colors.status("...parsing stock orders..."))
                     stocks_dict = PARSE_STOCK_ORDERS(stock_orders)
                 print()
-                print(f"--- Parsed Fulfilled Stock Orders ---")
+                print(colors.section(f"--- Parsed Fulfilled Stock Orders ---"))
                 PRINT_ORDERS_DICTIONARY(stocks_dict)
                 print()
             else: # not time consuming
                 if load_bool:
-                    print("...loading parsed stock orders...")
+                    print(colors.status("...loading parsed stock orders..."))
                     stocks_dict = ld["stocks_dict"]
                 else:
-                    print("...parsing stock orders...")
+                    print(colors.status("...parsing stock orders..."))
                     stocks_dict = PARSE_STOCK_ORDERS(stock_orders)
                 PRINT_ORDERS_DICTIONARY(stocks_dict)
                 print()
 
         # print all crypto orders (buy and sell)
         cryptos_dict = {}
-        print(f"--- All Crypto Orders ---")
+        print(colors.section(f"--- All Crypto Orders ---"))
         if crypto_orders != []:
             if extra_info_bool: # time consuming shows alot of extra information (like state of orders and more)
                 PRINT_CRYPTO_ORDERS(crypto_orders) ## time consuming
                 print()
                 if load_bool:
-                    print("...loading parsed crypto orders...")
+                    print(colors.status("...loading parsed crypto orders..."))
                     cryptos_dict = ld["cryptos_dict"]
                 else:
-                    print("...parsing crypto orders...")
+                    print(colors.status("...parsing crypto orders..."))
                     cryptos_dict = PARSE_CRYPTO_ORDERS(crypto_orders)
                 print()
-                print(f"--- Parsed Fulfilled Crypto Orders ---")
+                print(colors.section(f"--- Parsed Fulfilled Crypto Orders ---"))
                 PRINT_ORDERS_DICTIONARY(cryptos_dict)
                 print()
             else: # not time consuming
                 if load_bool:
-                    print("...loading parsed crypto orders...")
+                    print(colors.status("...loading parsed crypto orders..."))
                     cryptos_dict = ld["cryptos_dict"]
                 else:
-                    print("...parsing crypto orders...")
+                    print(colors.status("...parsing crypto orders..."))
                     cryptos_dict = PARSE_CRYPTO_ORDERS(crypto_orders)
                 PRINT_ORDERS_DICTIONARY(cryptos_dict)
                 print()
 
         # print all option orders (buy and sell)
         options_dict = {}
-        print(f"--- All Option Orders ---")
+        print(colors.section(f"--- All Option Orders ---"))
         if option_orders != []: # time consuming shows alot of extra information (like state of orders and more)
             PRINT_OPTION_ORDERS(option_orders)  ## time consuming
             print()
             if load_bool:
-                print("...loading parsed option orders...")
+                print(colors.status("...loading parsed option orders..."))
                 options_dict = ld["options_dict"]
             else:
-                print("...parsing option orders...")
+                print(colors.status("...parsing option orders..."))
                 options_dict = PARSE_OPTION_ORDERS(option_orders)
             print()
-            print(f"--- Parsed Fulfilled Option Orders ---")
+            print(colors.section(f"--- Parsed Fulfilled Option Orders ---"))
             PRINT_ORDERS_DICTIONARY(options_dict)
             print()
         else:  # not time consuming
             if load_bool:
-                print("...loading parsed option orders...")
+                print(colors.status("...loading parsed option orders..."))
                 options_dict = ld["options_dict"]
             else:
-                print("...parsing option orders...")
+                print(colors.status("...parsing option orders..."))
                 options_dict = PARSE_OPTION_ORDERS(option_orders)
             PRINT_ORDERS_DICTIONARY(options_dict)
             print()
 
         # show open positions
-        print("--- Open Positions ---")
+        print(colors.section("--- Open Positions ---"))
         total_stocks_open_amount, total_cryptos_open_amount, total_options_open_amount = (0, 0, 0)
         total_stocks_open_value, total_cryptos_open_value, total_options_open_value = (0, 0, 0)
         sod, cod, ood = [], [], [] # stock open list of dicts, crypto open list of dicts, option open list of dicts
@@ -724,7 +725,7 @@ def PRINT_ALL_PROFILE_AND_ORDERS(save_bool=False,load_bool=False, extra_info_boo
         # if stocks_open != []:
         if sum_of_stocks_open_quantity != 0:
             print()
-            print("STOCKS:")
+            print(colors.header("STOCKS:"))
             for i in stocks_open:
                 s = URL2SYM(i["instrument"])
                 a = float(i["quantity"])
@@ -745,15 +746,15 @@ def PRINT_ALL_PROFILE_AND_ORDERS(save_bool=False,load_bool=False, extra_info_boo
                 a = i["quantity"]
                 p = i["price"]
                 v = i["value"]
-                print(f"* OPEN STOCK - {s} x{a} at ${DX(p,5)} each - est current value: ${DX(v,5)}")
-            print(f"* TOTAL OPEN STOCKS - {total_stocks_open_amount} stocks for total ${DX(total_stocks_open_value,5)} estimated value")
+                print(f"* OPEN STOCK - {colors.symbol(s)} x{a} at ${DX(p,5)} each - est current value: {colors.green('$'+DX(v,5))}")
+            print(colors.bold(f"* TOTAL OPEN STOCKS - {total_stocks_open_amount} stocks for total ${DX(total_stocks_open_value,5)} estimated value"))
         # cryptos
         cryptos_open = ld["cryptos_open"] if load_bool else LOAD_OPEN_CRYPTOS()
         sum_of_cryptos_open_quantity = sum([ float(i["quantity"]) for i in cryptos_open ])
         # if cryptos_open != []:
         if sum_of_cryptos_open_quantity != 0:
             print()
-            print("CRYPTO:")
+            print(colors.header("CRYPTO:"))
             for i in cryptos_open:
                 s = i["currency"]["code"]
                 a = float(i["quantity"])
@@ -775,8 +776,8 @@ def PRINT_ALL_PROFILE_AND_ORDERS(save_bool=False,load_bool=False, extra_info_boo
                 a = i["quantity"]
                 p = i["price"]
                 v = i["value"]
-                print(f"* OPEN CRYPTO - {s} x{a} at ${DX(p,5)} each - est current value: ${DX(v,5)}")
-            print(f"* TOTAL OPEN CRYPTO - {total_cryptos_open_amount} stocks for total ${DX(total_cryptos_open_value,5)} estimated value")
+                print(f"* OPEN CRYPTO - {colors.symbol(s)} x{a} at ${DX(p,5)} each - est current value: {colors.green('$'+DX(v,5))}")
+            print(colors.bold(f"* TOTAL OPEN CRYPTO - {total_cryptos_open_amount} stocks for total ${DX(total_cryptos_open_value,5)} estimated value"))
         # TODO: options open positions
         options_open = ld["options_open"] if load_bool else LOAD_OPEN_OPTIONS()
         if options_open != []:
@@ -786,8 +787,8 @@ def PRINT_ALL_PROFILE_AND_ORDERS(save_bool=False,load_bool=False, extra_info_boo
             total_open_amount = total_stocks_open_amount, total_cryptos_open_amount, total_options_open_amount
             total_open_value = total_stocks_open_value + total_cryptos_open_value + total_options_open_value
             print()
-            print("TOTAL:")
-            print(f"* total open positions value: ${D2(total_open_value)}")
+            print(colors.header("TOTAL:"))
+            print(f"* total open positions value: {colors.bold('$'+D2(total_open_value))}")
 
         # quick inner function for profit printing
         def show_profits_from_orders_dictionary(dictionary, prefix=""):
@@ -817,41 +818,41 @@ def PRINT_ALL_PROFILE_AND_ORDERS(save_bool=False,load_bool=False, extra_info_boo
             for i in list_dict:
                 sym = i["symbol"]
                 last_profit = i["profit"]
-                open_string = " ** currently open **" if i["open"] else ""
-                print(f"* {prefix}{sym} net profit ${D2(last_profit)}"+open_string)
-            print(f"* {prefix}total net profit ${D2(total_profit)}")
+                open_string = colors.open_marker(" ** currently open **") if i["open"] else ""
+                print(f"* {prefix}{colors.symbol(sym)} net profit {colors.profit(last_profit)}"+open_string)
+            print(colors.bold(f"* {prefix}total net profit {colors.profit(total_profit)}"))
             return (total_profit, total_amount, list_dict)
 
         # show each stocks profit
         print()
-        print(f"--- Profits Based On Orders + Open Positions ---")
-        print("* NOTE: For this profit approximation, add up every symbol's sell values, subtract the buy values, and if the symbol is currently open add in the current open value based on current ask price for the symbol")
-        print("* NOTE: This is an approximation - albiet a good one, because symbols which are currently open their current ask price is constantly fluctuating.")
-        print("* NOTE: If your portfolio has no open symbols, then this is not an approximation but a very close actual value.")
-        print("* NOTE: profit per stock = (current open position value) + (sum of all of the sells) - (sum of all of the buy orders)")
+        print(colors.section(f"--- Profits Based On Orders + Open Positions ---"))
+        print(colors.note("* NOTE: For this profit approximation, add up every symbol's sell values, subtract the buy values, and if the symbol is currently open add in the current open value based on current ask price for the symbol"))
+        print(colors.note("* NOTE: This is an approximation - albiet a good one, because symbols which are currently open their current ask price is constantly fluctuating."))
+        print(colors.note("* NOTE: If your portfolio has no open symbols, then this is not an approximation but a very close actual value."))
+        print(colors.note("* NOTE: profit per stock = (current open position value) + (sum of all of the sells) - (sum of all of the buy orders)"))
         total_stocks_profit, total_stocks_amount, total_cryptos_profit, total_cryptos_amount, total_options_profit, total_options_amount = 0,0,0,0,0,0
         list_dict_of_stock_profits, list_dict_of_crypto_profits, list_dict_of_option_profits = [], [], []
         profits_dict = {}
         if stock_orders != []:
             print()
-            print(f"STOCKS:")
+            print(colors.header(f"STOCKS:"))
             total_stocks_profit, total_stocks_amount, list_dict_of_stock_profits = show_profits_from_orders_dictionary(stocks_dict,"STOCK ")
         if crypto_orders != []:
             print()
-            print(f"CRYPTO:")
+            print(colors.header(f"CRYPTO:"))
             total_cryptos_profit, total_cryptos_amount, list_dict_of_crypto_profits = show_profits_from_orders_dictionary(cryptos_dict, "CRYPTO ")
         if option_orders != []:
             print()
-            print(f"OPTIONS:")
+            print(colors.header(f"OPTIONS:"))
             total_options_profit, total_options_amount, list_dict_of_option_profits = show_profits_from_orders_dictionary(options_dict, "OPTION ")
         complete_profit = total_stocks_profit + total_cryptos_profit + total_options_profit
         print()
-        print("TOTAL NET PROFIT:")
-        print(f"* total net profit from stocks, crypto, and options: ${D2(complete_profit)}")
+        print(colors.header("TOTAL NET PROFIT:"))
+        print(colors.bold(f"* total net profit from stocks, crypto, and options: {colors.profit(complete_profit)}"))
         print()
 
         # dividend profit
-        print(f"--- Profits from Dividends ---")
+        print(colors.section(f"--- Profits from Dividends ---"))
         rs_divs_list = ld["dividends"] if load_bool else LOAD_DIVIDENDS()
         if rs_divs_list != [] or rs_divs_list is not None: # maybe just checking != [] is enough, doesn't hurt to check for None as well
             divs_list = []
@@ -873,13 +874,14 @@ def PRINT_ALL_PROFILE_AND_ORDERS(save_bool=False,load_bool=False, extra_info_boo
             #    sort(divs_list,key=lambda x: x.amount_paid)
             divs_list.sort(key=lambda x: x.date_epoch)
             for i in divs_list:
-                print(f"* dividend from {i.symbol_name} on {i.date_nice()} for ${D2(i.payed_amount)} ({i.state})")
-            print(f"TOTAL PAID DIVIDEND PROFIT: ${D2(divs_sum)}")
+                state_colored = colors.green(i.state) if i.state == "paid" else colors.yellow(i.state)
+                print(f"* dividend from {colors.symbol(i.symbol_name)} on {i.date_nice()} for {colors.green('$'+D2(i.payed_amount))} ({state_colored})")
+            print(colors.bold(f"TOTAL PAID DIVIDEND PROFIT: {colors.bright_green('$'+D2(divs_sum))}"))
             print()
 
-        print("--- Total Profit (Net Profit + Dividends) ---")
+        print(colors.section("--- Total Profit (Net Profit + Dividends) ---"))
         complete_profit_plus_divs = complete_profit + divs_sum
-        print(f"* total profit from stocks, crypto, and options + dividends: ${D2(complete_profit_plus_divs)}")
+        print(colors.bold(f"* total profit from stocks, crypto, and options + dividends: {colors.profit(complete_profit_plus_divs)}"))
         print()
 
     ### TESTING
@@ -898,51 +900,51 @@ def PRINT_ALL_PROFILE_AND_ORDERS(save_bool=False,load_bool=False, extra_info_boo
     # print()
 
     # print extra info footer
-    print(f"--- Final Notes ---")
+    print(colors.section(f"--- Final Notes ---"))
 
     # if profile info was saved to csv
     dir_full = get_save_dir()
 
     if info_type == "ALL" or info_type == "PROFILE":
         if csv_profile_bool:
-            print(f"* saved profile data csvs to '{dir_full}' directory")
+            print(colors.status(f"* saved profile data csvs to '{dir_full}' directory"))
 
     if info_type == "PROFILE" and csv_profile_bool == False:
-        print("* none")
+        print(colors.dim("* none"))
 
     # if we loaded order data from api or dat.pkl file
     if info_type == "ALL" or info_type == "FINANCE":
         if load_bool:
-            print(f"* loaded order data from '{FILENAME}' which ran on {run_date_orders}")
+            print(colors.status(f"* loaded order data from '{FILENAME}' which ran on {run_date_orders}"))
         else:
-            print(f"* loaded order data from robinhood API run date {run_date_orders}")
+            print(colors.status(f"* loaded order data from robinhood API run date {run_date_orders}"))
 
     # save to order , open , and profit to csv
     if info_type == "ALL" or info_type == "FINANCE":
         if csv_bool:
             if stock_orders != []:
-                print(f"* saving stock orders + open positions + net profits csvs to '{dir_full}' directory")
+                print(colors.status(f"* saving stock orders + open positions + net profits csvs to '{dir_full}' directory"))
                 print_all_stocks_to_csv(stock_orders)
                 print_to_csv("All-Profits-Stocks",list_dict_of_stock_profits)
                 if sod != []:
                     print_to_csv("All-Open-Stocks",sod)
-                print(f"* saved stock csvs")
+                print(colors.status(f"* saved stock csvs"))
             if crypto_orders != []:
-                print(f"* saving crypto orders + open positions + net profits csvs to '{dir_full}' directory")
+                print(colors.status(f"* saving crypto orders + open positions + net profits csvs to '{dir_full}' directory"))
                 print_all_crypto_to_csv(crypto_orders)
                 print_to_csv("All-Profits-Crypto",list_dict_of_crypto_profits)
                 if cod != []:
                     print_to_csv("All-Open-Crypto",cod)
-                print(f"* saved crypto csvs")
+                print(colors.status(f"* saved crypto csvs"))
             if option_orders != []:
-                print(f"* saving option orders + open positions + net profits csvs to '{dir_full}' directory")
+                print(colors.status(f"* saving option orders + open positions + net profits csvs to '{dir_full}' directory"))
                 print_all_options_to_csv(option_orders)
                 print_to_csv("All-Profits-Options",list_dict_of_option_profits)
                 if ood != []:
                     print_to_csv("All-Open-Options",ood)
-                print(f"* saved option csvs")
+                print(colors.status(f"* saved option csvs"))
             if rs_divs_list != []:
-                print(f"* saving dividends csv to '{dir_full}'")
+                print(colors.status(f"* saving dividends csv to '{dir_full}'"))
                 print_to_csv("All-Dividends",rs_divs_list)
 
         # Save api data to pickle file dat.pkl so we can use --load in future to load faster (but of course then its not live data)
@@ -979,8 +981,12 @@ def main():
     parser.add_argument("--profile-csv","-p",help="Save all profile data to csv. Only works if --profile-info or --all-info used as well.", action="store_true")
     parser.add_argument("--csv-dir","-D",help=f"Change output directory for csv files generated by --csv and --profile-csv option, by default the directory is named '{dir_suffix}'.", action="store", default=dir_suffix)
     parser.add_argument("--sort-by-name","-S",help="Sorts open positions + profits by name instead of value. Only works if --finance-info or --all-info is used as well.", action="store_true")
+    parser.add_argument("--color",help="Color output: auto (default, color if terminal), always (force color), never (no color).", action="store", default="auto", choices=["auto","always","never"])
 
     args = parser.parse_args()
+
+    # initialize color output
+    colors.init(args.color)
 
     # parse save and load
     save_bool = args.save


### PR DESCRIPTION
**New colors.py module provides ANSI color support with three modes:**
- auto (default): color when stdout is a TTY, plain when piped/redirected
- always: force color output regardless of terminal
- never: no color codes, identical to previous output

**Color scheme:**
- Section headers (--- ... ---): bold cyan
- Category labels (STOCKS:, TOTAL:): bold white
- NOTE lines: yellow
- Error messages: bold red
- Buy orders: red, Sell orders: green
- Positive profits: bright green, Negative profits: bright red
- Open position markers: bold yellow
- Symbol names: bold
- Loading/status messages: dim
- Profile keys: cyan

**Color example:**

<img width="406" height="323" alt="image" src="https://github.com/user-attachments/assets/fb6e6cc8-efe4-4f55-985f-0e418fad22c6" />


All original output text and information is preserved exactly. CLAUDE.md updated to document colors.py and --color flag.

https://claude.ai/code/session_0171w3S2gPZhaLvyvMqPk6Hn

**Updated**: README, old one went to _archive directory, and requirements files to the latest robin-stocks v3.4.0